### PR TITLE
Fix pagination to include query parameters in all HTTP GET requests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -58,6 +58,10 @@ Metrics/ClassLength:
 Metrics/MethodLength:
   Enabled: false
 
+Metrics/BlockLength:
+  Exclude:
+    - "**/*_spec.rb"
+
 Metrics/ParameterLists:
   Max: 5
   CountKeywordArgs: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -32,7 +32,7 @@ Style/NumericLiterals:
   Enabled: false
 
 Style/CaseIndentation:
-  IndentWhenRelativeTo: end
+  EnforcedStyle: end
 
 Style/IndentHash:
   EnforcedStyle: consistent
@@ -66,7 +66,7 @@ Metrics/PerceivedComplexity:
   Enabled: false
 
 Lint/EndAlignment:
-  AlignWith: variable
+  EnforcedStyleAlignWith: variable
 
 Style/FrozenStringLiteralComment:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
-gem 'rake'
 gem 'byebug'
+gem 'rake'
 gem 'rubocop'
 gem 'yard'
 

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -58,14 +58,13 @@ module Oktakit
       }
 
       resp, status, next_page = request :get, url, **request_options
-      return [resp, status] unless status == 200
 
-      # If we should paginate, then automatically traverse all next_pages
-      if should_paginate
+      # If request succeeded and we should paginate, then automatically traverse all next_pages
+      if status == 200 && should_paginate
         all_objs = [resp]
         while next_page
           resp, status, next_page = request :get, next_page, **request_options
-          break unless status == 200
+          break unless status == 200 # Return early if page request fails
 
           all_objs << resp
         end

--- a/lib/oktakit/version.rb
+++ b/lib/oktakit/version.rb
@@ -1,3 +1,3 @@
 module Oktakit
-  VERSION = '0.1.3'.freeze
+  VERSION = '0.1.4'.freeze
 end

--- a/spec/cassettes/pagination_with_query_params.yml
+++ b/spec/cassettes/pagination_with_query_params.yml
@@ -1,0 +1,194 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7/users?expand=user&limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Oktakit v0.1.3
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      date:
+      - Thu, 02 Mar 2017 20:36:36 GMT
+      server:
+      - nginx
+      content-type:
+      - application/json;charset=UTF-8
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - WLiCVF8U4UhgCxUWInBa7wAAAhI
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '1200'
+      x-rate-limit-remaining:
+      - '1188'
+      x-rate-limit-reset:
+      - '1488487008'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      link:
+      - <https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7/users?limit=1>;
+        rel="self", <https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7/users?after=0uabjltuhb3i1DFvQ0x7&limit=1>;
+        rel="next"
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=1498FF89EDE06E569A4A561223D8E71B;
+        Path=/
+      connection:
+      - close
+      transfer-encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"id":"00u3krc0foy2vAhng0x7","externalId":null,"created":"2017-02-03T00:15:33.000Z","lastUpdated":"2017-02-03T00:15:33.000Z","scope":"USER","status":"ACTIVE","statusChanged":"2017-02-03T00:15:33.000Z","passwordChanged":null,"syncState":"DISABLED","lastSync":null,"credentials":{"userName":"fred.jones@okta-test.com"},"profile":{},"_links":{"app":{"href":"https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7"},"user":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7"}},"_embedded":{"user":{"id":"00u3krc0foy2vAhng0x7","status":"ACTIVE","created":"2015-12-14T21:29:59.000Z","activated":"2015-12-14T21:29:59.000Z","statusChanged":"2015-12-17T20:50:07.000Z","lastLogin":"2017-02-27T02:11:38.000Z","lastUpdated":"2017-03-02T16:00:21.000Z","passwordChanged":"2015-12-17T20:50:07.000Z","profile":{"login":"fred.jones@okta-test.com","mobilePhone":"","email":"fred.jones@okta-test.com","secondEmail":null,"firstName":"Fred","lastName":"Jones","streetAddress":"","manager":"","department":"","countryCode":"","state":"","costCenter":"",
+        "city":"","organization":"","title":"","primaryPhone":"","zipCode":""},"credentials":{"password":{},"recovery_question":{"question":"What''s your first pet''s name?"},"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7/lifecycle/suspend","method":"POST"},"resetPassword":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7/lifecycle/reset_password","method":"POST"},"resetFactors":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7/lifecycle/reset_factors","method":"POST"},"expirePassword":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7/lifecycle/expire_password","method":"POST"},"forgotPassword":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7/credentials/forgot_password","method":"POST"},"self":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7"},"changeRecoveryQuestion":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7/credentials/change_recovery_question","method":"POST"},
+        "deactivate":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7/lifecycle/deactivate","method":"POST"},"changePassword":{"href":"https://okta-test.okta.com/api/v1/users/00u3krc0foy2vAhng0x7/credentials/change_password","method":"POST"}}}}}]'
+    http_version:
+  recorded_at: Thu, 02 Mar 2017 20:36:36 GMT
+- request:
+    method: get
+    uri: https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7/users?after=0uabjltuhb3i1DFvQ0x7&expand=user&limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Oktakit v0.1.3
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      date:
+      - Thu, 02 Mar 2017 20:36:37 GMT
+      server:
+      - nginx
+      content-type:
+      - application/json;charset=UTF-8
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - WLiCVOnEBdD6iy7DGPf2qwAACf4
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '1200'
+      x-rate-limit-remaining:
+      - '1187'
+      x-rate-limit-reset:
+      - '1488487008'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      link:
+      - <https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7/users?after=0uabjltuhb3i1DFvQ0x7&limit=1>;
+        rel="self", <https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7/users?after=0uablg4csyYtROpzz0x7&limit=1>;
+        rel="next"
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=0175917BA3CC527F851C8D3C4252A100;
+        Path=/
+      connection:
+      - close
+      transfer-encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"id":"00tau9t0s8v3cQ91G0x7","externalId":null,"created":"2017-02-24T20:29:04.000Z","lastUpdated":"2017-02-24T20:29:04.000Z","scope":"USER","status":"ACTIVE","statusChanged":"2017-02-24T20:29:04.000Z","passwordChanged":null,"syncState":"DISABLED","lastSync":null,"credentials":{"userName":"nancy.smith@okta-test.com"},"profile":{},"_links":{"app":{"href":"https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7"},"user":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7"}},"_embedded":{"user":{"id":"00tau9t0s8v3cQ91G0x7","status":"ACTIVE","created":"2015-12-14T21:49:15.000Z","activated":"2015-12-14T21:49:15.000Z","statusChanged":"2015-12-15T14:47:00.000Z","lastLogin":"2017-02-13T18:50:03.000Z","lastUpdated":"2017-01-30T20:31:22.000Z","passwordChanged":"2015-12-15T14:47:00.000Z","profile":{"login":"nancy.smith@okta-test.com","firstName":"Nancy","lastName":"Smith","mobilePhone":"","email":"nancy.smith@okta-test.com","secondEmail":null,"streetAddress":"","title":"","organization":"","manager":"","primaryPhone":"","department":"","zipCode":"","countryCode":"","state":"","costCenter":"","city":""},
+      "credentials":{"password":{},"recovery_question":{"question":"Who is your favorite sports player?"},"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7/lifecycle/suspend","method":"POST"},"resetPassword":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7/lifecycle/reset_password","method":"POST"},"resetFactors":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7/lifecycle/reset_factors","method":"POST"},"expirePassword":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7/lifecycle/expire_password","method":"POST"},"forgotPassword":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7/credentials/forgot_password","method":"POST"},"self":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7"},"changeRecoveryQuestion":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7/credentials/change_recovery_question","method":"POST"},"deactivate":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7/lifecycle/deactivate","method":"POST"},
+      "changePassword":{"href":"https://okta-test.okta.com/api/v1/users/00tau9t0s8v3cQ91G0x7/credentials/change_password","method":"POST"}}}}}]'
+    http_version:
+  recorded_at: Thu, 02 Mar 2017 20:36:37 GMT
+- request:
+    method: get
+    uri: https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7/users?after=0uablg4csyYtROpzz0x7&expand=user&limit=1
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Oktakit v0.1.3
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message:
+    headers:
+      date:
+      - Thu, 02 Mar 2017 20:39:52 GMT
+      server:
+      - nginx
+      content-type:
+      - application/json;charset=UTF-8
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - WLiDF2QJ5JGUHYFcEHg5eQAADTE
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '1200'
+      x-rate-limit-remaining:
+      - '1195'
+      x-rate-limit-reset:
+      - '1488487248'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      link:
+      - <https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7/users?after=0uablg4csyYtROpzz0x7&limit=1>;
+        rel="self"
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=3011A3A764765405DC942434D3B2176B;
+        Path=/
+      connection:
+      - close
+      transfer-encoding:
+      - chunked
+    body:
+      encoding: UTF-8
+      string: '[{"id":"00u2KfbkaUBHftHaj0x7","externalId":null,"created":"2017-02-28T21:09:03.000Z","lastUpdated":"2017-02-28T21:09:03.000Z","scope":"GROUP","status":"ACTIVE","statusChanged":"2017-02-28T21:09:03.000Z","passwordChanged":null,"syncState":"DISABLED","lastSync":null,"credentials":{"userName":"jack.johns@okta-test.com"},"profile":{},"_links":{"app":{"href":"https://okta-test.okta.com/api/v1/apps/0oaYAubtaubhslaOg0x7"},"group":{"name":"Team
+        Okta-Test","href":"https://okta-test.okta.com/api/v1/groups/00g1cuhdz4NhNgvwP0x7"},"user":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7"}},"_embedded":{"user":{"id":"00u2KfbkaUBHftHaj0x7","status":"ACTIVE","created":"2017-02-14T01:11:36.000Z","activated":"2017-02-14T01:11:37.000Z","statusChanged":"2017-02-20T16:52:37.000Z","lastLogin":"2017-03-02T14:56:41.000Z","lastUpdated":"2017-02-20T16:52:37.000Z","passwordChanged":"2017-02-20T16:52:37.000Z","profile":{"mobilePhone":"","email":"jack.johns@okta-test.com","secondEmail":null,"firstName":"Jack","lastName":"Johns","login":"jack.johns@okta-test.com","streetAddress":"","organization":"","title":"","manager":"","primaryPhone":"","department":"","zipCode":"","countryCode":"","state":"","costCenter":"","city":"","ssh_public_keys":""},"credentials":{"password":{},"recovery_question":{"question":"Where
+        did you go for your favorite vacation?"},"provider":{"type":"OKTA","name":"OKTA"}},"_links":{"suspend":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7/lifecycle/suspend","method":"POST"},"resetPassword":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7/lifecycle/reset_password","method":"POST"},"resetFactors":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7/lifecycle/reset_factors","method":"POST"},"expirePassword":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7/lifecycle/expire_password","method":"POST"},"forgotPassword":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7/credentials/forgot_password","method":"POST"},"self":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7"},"changeRecoveryQuestion":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7/credentials/change_recovery_question","method":"POST"},"deactivate":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7/lifecycle/deactivate","method":"POST"},"changePassword":{"href":"https://okta-test.okta.com/api/v1/users/00u2KfbkaUBHftHaj0x7/credentials/change_password","method":"POST"}}}}}]'
+    http_version:
+  recorded_at: Thu, 02 Mar 2017 20:39:52 GMT
+recorded_with: VCR 3.0.3

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -13,7 +13,8 @@ describe Oktakit do
 
   it 'should send query parameters in each page request' do
     VCR.use_cassette 'pagination_with_query_params' do
-      users, = client.list_users_assigned_to_application(PAGED_APPS_APP_ID, paginate: true, query: {expand: 'user', limit: '1'})
+      users, = client.list_users_assigned_to_application(PAGED_APPS_APP_ID,
+        paginate: true, query: { expand: 'user', limit: '1' })
       users.each do |user|
         expect(user._embedded).not_to be_nil, "User #{user.id} was expected to have expanded user profile in _embedded"
       end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -2,10 +2,23 @@ require 'spec_helper'
 require 'byebug'
 
 describe Oktakit do
+  PAGED_APPS_APP_ID = '0oaYAubtaubhslaOg0x7'
+
   it 'should auto paginate' do
-    VCR.use_cassette 'pagination', record: :new_episodes do
+    VCR.use_cassette 'pagination' do
       users, = client.list_users(paginate: true)
       expect(users.size).to be == 10
+    end
+  end
+
+  it 'should send query parameters in each page request' do
+    VCR.use_cassette 'pagination_with_query_params' do
+      users, = client.list_users_assigned_to_application(PAGED_APPS_APP_ID, paginate: true, query: {expand: 'user', limit: '1'})
+      users.each do |user|
+        expect(user._embedded).not_to be_nil, "User #{user.id} was expected to have expanded user profile in _embedded"
+      end
+
+      expect(users.size).to be == 3
     end
   end
 end


### PR DESCRIPTION
Please 👀  @jules2689 
This fixes the Oktakit pagination so that it will send the same query parameters (and headers, etc.) to Okta for every HTTP GET request done to retrieve all of the pages.