### PR TITLE
A domain name should be all lowercase

### DIFF
--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -185,7 +185,7 @@ module Oktakit
     end
 
     def api_endpoint
-      "https://#{@organization}.okta.com/api/v1"
+      "https://#{@organization.downcase}.okta.com/api/v1"
     end
 
     def absolute_to_relative_url(next_ref)


### PR DESCRIPTION
Newer version of Sawyer automatically convert domain names to lowercase, but this confuses the logic to strip the domain name and protocol off of a URL to get a path.