### PR TITLE
Add support for developer organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,14 @@ client = Oktakit.new(token: 't0k3n', organization: 'my-great-org')
 response, http_status = client.list_users
 ```
 
+#### Developer organization
+Pass the 'developer_org' flag as option on client initialization in case you don't have a production okta account yet. This will change the API endpoint to oktapreview.com.
+
+```ruby
+client = Oktakit.new(token: 't0k3n', organization: 'my-great-org', developer_org: true)
+response, http_status = client.list_users
+```
+
 #### Pagination
 Pass the `paginate` flag as options for any `get` action for Oktakit to autopaginate the response for you.
 

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -31,9 +31,10 @@ module Oktakit
       builder.adapter Faraday.default_adapter
     end
 
-    def initialize(token:, organization:)
+    def initialize(token:, organization:, developer_org:)
       @token = token
       @organization = organization
+      @developer_org = developer_org
     end
 
     # Make a HTTP GET request
@@ -184,8 +185,12 @@ module Oktakit
       }
     end
 
+    def okta_domain
+      @developer_org ? 'oktapreview' : 'okta'
+    end
+
     def api_endpoint
-      "https://#{@organization.downcase}.okta.com/api/v1"
+      "https://#{@organization.downcase}.#{okta_domain}.com/api/v1"
     end
 
     def absolute_to_relative_url(next_ref)

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -31,7 +31,7 @@ module Oktakit
       builder.adapter Faraday.default_adapter
     end
 
-    def initialize(token:, organization:, developer_org:)
+    def initialize(token:, organization:, developer_org: false)
       @token = token
       @organization = organization
       @developer_org = developer_org

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ require 'oktakit'
 
 module TestClient
   extend RSpec::SharedContext
-  let(:client) { Oktakit::Client.new(token: test_okta_token, organization: 'okta-test') }
+  let(:client) { Oktakit::Client.new(token: test_okta_token, organization: 'okta-test', developer_org: false) }
 end
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,7 @@ require 'oktakit'
 
 module TestClient
   extend RSpec::SharedContext
-  let(:client) { Oktakit::Client.new(token: test_okta_token, organization: 'okta-test', developer_org: false) }
+  let(:client) { Oktakit::Client.new(token: test_okta_token, organization: 'okta-test') }
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
Api endpoint is different for Okta Org Type 'Developer'.