### PR TITLE
Added option to set the `api_endpoint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ client = Oktakit.new(token: 't0k3n', organization: 'my-great-org')
 response, http_status = client.list_users
 ```
 
+To work with the Okta sandbox (`<organization>.oktapreview.com`), set the `api_endpoint`:
+
+```ruby
+client = Oktakit.new(token: 't0k3n', api_endpoint: 'https://my-great-org.oktapreview.com/api/v1')
+```
+
 #### Pagination
 Pass the `paginate` flag as options for any `get` action for Oktakit to autopaginate the response for you.
 

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -31,10 +31,22 @@ module Oktakit
       builder.adapter Faraday.default_adapter
     end
 
-    def initialize(token:, organization:)
+    def initialize(token:, organization: nil, api_endpoint: nil)
+      raise ArgumentError, "Please provide either the organization or the api_endpoint argument" if organization.nil? && api_endpoint.nil?
+
       @token = token
       @organization = organization
+      @api_endpoint = api_endpoint
     end
+
+    def api_endpoint
+      if @api_endpoint
+        @api_endpoint
+      else
+        "https://#{@organization.downcase}.okta.com/api/v1"
+      end
+    end
+
 
     # Make a HTTP GET request
     #
@@ -182,10 +194,6 @@ module Oktakit
         links_parser: Sawyer::LinkParsers::Simple.new,
         faraday: Faraday.new(builder: MIDDLEWARE),
       }
-    end
-
-    def api_endpoint
-      "https://#{@organization.downcase}.okta.com/api/v1"
     end
 
     def absolute_to_relative_url(next_ref)

--- a/spec/oktakit_spec.rb
+++ b/spec/oktakit_spec.rb
@@ -5,6 +5,22 @@ describe Oktakit do
     expect(Oktakit::VERSION).not_to be nil
   end
 
+  describe 'client' do
+    it 'has a default API endpoint' do
+      client = Oktakit::Client.new(token: test_okta_token, organization: 'okta-test')
+      expect(client.api_endpoint).to eq('https://okta-test.okta.com/api/v1')
+    end
+
+    it 'allows to configure the API endpoint' do
+      client = Oktakit::Client.new(token: test_okta_token, api_endpoint: 'https://okta-test.oktapreview.com/api/v1')
+      expect(client.api_endpoint).to eq('https://okta-test.oktapreview.com/api/v1')
+    end
+
+    it 'raises ArgumentError when no organization or api_endpoint is provided' do
+      expect { Oktakit::Client.new(token: test_okta_token) }.to raise_error(ArgumentError)
+    end
+  end
+
   ERRORS = {
     400 => Oktakit::BadRequest,
     401 => Oktakit::Unauthorized,


### PR DESCRIPTION
Hi,

I need to execute the API calls againt the Okta "sandbox" (`<organization>.oktapreview.com`), not the default API endpoint.

In order to do so, I've refactored the `Oktakit::Client#api_endpoint` method, and added a new keyword argument for the `Oktakit::Client#initialize` method. (I've also changed the visibility of the `api_endpoint` method to public, in order to facilitate unit testing, I think there's no harm if this method is accessed from the outside.)

The client now allows to set _either_ the `organization:` or `api_endpoint:` argument, so either the default endpoint is used, or the one provided by the user. If none of those is provided, an `ArgumentError` exception will be raised.