### PR TITLE
Error parsing

### DIFF
--- a/lib/oktakit/client/users.rb
+++ b/lib/oktakit/client/users.rb
@@ -195,22 +195,6 @@ module Oktakit
         post("/users/#{id}/lifecycle/unlock", options)
       end
 
-      # Delete User
-      #
-      # @params id [string] User ID
-      # @param options[:query] [Hash] Optional. Query params for request
-      # @param options[:headers] [Hash] Optional. Header params for the request.
-      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
-      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
-      # @param options [Hash] Optional. Body params for request.
-      # @return [Hash<Sawyer::Resource>] Returns an empty object.
-      # @see https://developer.okta.com/docs/api/resources/users#delete-user
-      # @example
-      #   Oktakit.delete_user('id')
-      def suspend_user(id, options = {})
-        delete("/users/#{id}", options)
-      end
-
       # Reset Password
       #
       # @params id [string] User ID


### PR DESCRIPTION
Currently, errors returned from the API are not parsed correctly, and the response information is not accessible