### PR TITLE
Add group rule endpoints

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -1,0 +1,130 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+that.hector@gmail.com.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series
+of actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or
+permanent ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior,  harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+Community Impact Guidelines were inspired by [Mozilla's code of conduct
+enforcement ladder](https://github.com/mozilla/diversity).
+
+[homepage]: https://www.contributor-covenant.org
+
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.
+

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,61 @@
+# Oktakit Contributing Guide
+
+Thank you for showing interest in contributing! Before you start contributing,
+plesae make sure that you take a look at the following guidelines and adhere to
+them:
+
+- [Code of
+  Conduct](https://github.com/hectron/oktakit/blob/main/.github/CODE_OF_CONDUCT.md)
+- [Pull Request Guidelines](#pull-request-guidelines)
+- [Development Setup](#development-setup)
+
+## Pull Request Guidelines
+
+1. [Fork this repository](https://github.com/hectron/oktakit/fork)
+1. Create your feature branch (`git checkout -b my-new-feature`)
+1. Commit your changes (`git commit -am 'Add some feature'`)
+1. Push to the branch (`git push origin my-new-feature`)
+1. Create a new Pull Request
+
+- If you are adding a new feature:
+  - Add test coverage
+  - Provide an explanation of why this feature is needed, why you took the
+    approach that you decided on, and some screenshots of it in action.
+
+- If you are fixing a bug:
+  - If you are resolving a special issue, add `(fix #xxxx[,#xxxx])` (`#xxxx` is
+    the issue id) in your PR title for a better release log, e.g. `fix users
+    update endpoint (fix #2112)`
+  - Provide a detailed description of the bug in the PR, and steps to recreate
+    the bug on a fresh clone.
+  - Add appropriate test coverage
+
+- It's OK to have multiple small commits -- they will be automatically squahed
+  before it is merged in
+
+- Make sure you've run the test suite
+
+## Development Setup
+
+After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.
+
+To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
+
+### Testing
+
+To run the test suite, run:
+
+```bash
+$ bundle exec rspec
+```
+
+Testing is fairly straightforward, with the exception of the org URL.
+To anonymize the VCR data, first setup a real token and endpoint for Okta, such as `myokta.okta.com`
+
+- In `spec_helper.rb`, set the org to `my-okta` (or whatever your organization is).
+- Set the `OKTA_TEST_TOKEN` environment variable (this should be real). Don't worry, it is automatically removed.
+- Before committing, change `my-okta` to `okta-test` in `spec_helper.rb` and any VCR Cassettes.
+
+The [API Test Client](https://developer.okta.com/docs/api/getting_started/api_test_client) provided by Okta is also really helpful.
+
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
+        key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,10 +27,11 @@ jobs:
     - uses: actions/cache@v2
       with:
         path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        key: ${{ runner.os }}-gems-${{ hashFiles('Gemfile.lock') }}
         restore-keys: |
           ${{ runner.os }}-gems-
     - name: Install dependencies
+      if: steps.cache.outputs.cache-hit != 'true'
       run: |
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# This workflow uses actions that are not certified by GitHub.
+# They are provided by a third-party and are governed by
+# separate terms of service, privacy policy, and support
+# documentation.
+# This workflow will download a prebuilt Ruby version, install dependencies and run tests with Rake
+# For more information see: https://github.com/marketplace/actions/setup-ruby-jruby-and-truffleruby
+
+name: Continuous Integration
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby: ['2.4', '2.5', '2.6', '2.7']
+    steps:
+    - uses: actions/checkout@v2
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby }}
+    - name: Install dependencies
+      run: bundle install
+    # - name: Rubocop checks
+    #   uses: gimenete/rubocop-action@1.0
+    - name: Run tests
+      run: bundle exec rspec

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         path: vendor/bundle
         key: ${{ runner.os }}-${{ matrix.ruby }}-gems-${{ hashFiles('**/Gemfile.lock') }}
         restore-keys: |
-          ${{ runner.os }}-gems-
+          ${{ runner.os }}-${{ matrix.ruby }}-gems-
     - name: Install dependencies
       if: steps.cache.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,9 +24,17 @@ jobs:
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+    - uses: actions/cache@v2
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
     - name: Install dependencies
-      run: bundle install
-    # - name: Rubocop checks
-    #   uses: gimenete/rubocop-action@1.0
+      run: |
+        bundle config path vendor/bundle
+        bundle install --jobs 4 --retry 3
+    - name: Rubocop checks
+      run: bundle exec rubocop
     - name: Run tests
       run: bundle exec rspec

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 /.bundle/
 /.yardoc
-/Gemfile.lock
 /_yardoc/
 /coverage/
 /doc/

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,10 +2,7 @@
 #   http://shopify.github.io/ruby-style-guide/
 
 AllCops:
-  TargetRubyVersion: 2.2
-
-Rails:
-  Enabled: false
+  TargetRubyVersion: 2.4
 
 Lint/AssignmentInCondition:
   Enabled: false
@@ -16,10 +13,10 @@ Style/Documentation:
 Layout/MultilineOperationIndentation:
   Enabled: false
 
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
-Layout/FirstParameterIndentation:
+Layout/FirstArgumentIndentation:
   EnforcedStyle: consistent
 
 Style/TrailingCommaInArrayLiteral:
@@ -34,7 +31,7 @@ Style/NumericLiterals:
 Layout/CaseIndentation:
   EnforcedStyle: end
 
-Layout/IndentHash:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 Style/WordArray:
@@ -79,9 +76,6 @@ Style/Alias:
   EnforcedStyle: prefer_alias_method
 
 Style/MutableConstant:
-  Enabled: false
-
-Performance/Casecmp:
   Enabled: false
 
 Style/GuardClause:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,79 @@
+GIT
+  remote: https://github.com/vcr/vcr.git
+  revision: 480304be6d73803e6c4a0eb21a4ab4091da558d8
+  ref: 480304be6d73803e6c4a0eb21a4ab4091da558d8
+  branch: master
+  specs:
+    vcr (2.9.3)
+
+PATH
+  remote: .
+  specs:
+    oktakit (0.2.0)
+      sawyer (~> 0.8.1)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.7.0)
+      public_suffix (>= 2.0.2, < 5.0)
+    ast (2.4.1)
+    byebug (11.1.3)
+    diff-lcs (1.4.1)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
+    multipart-post (2.1.1)
+    parallel (1.19.2)
+    parser (2.7.1.4)
+      ast (~> 2.4.1)
+    public_suffix (4.0.5)
+    rainbow (3.0.0)
+    rake (13.0.1)
+    regexp_parser (1.7.1)
+    rexml (3.2.4)
+    rspec (3.9.0)
+      rspec-core (~> 3.9.0)
+      rspec-expectations (~> 3.9.0)
+      rspec-mocks (~> 3.9.0)
+    rspec-core (3.9.2)
+      rspec-support (~> 3.9.3)
+    rspec-expectations (3.9.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-mocks (3.9.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.9.0)
+    rspec-support (3.9.3)
+    rubocop (0.86.0)
+      parallel (~> 1.10)
+      parser (>= 2.7.0.1)
+      rainbow (>= 2.2.2, < 4.0)
+      regexp_parser (>= 1.7)
+      rexml
+      rubocop-ast (>= 0.0.3, < 1.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (>= 1.4.0, < 2.0)
+    rubocop-ast (0.0.3)
+      parser (>= 2.7.0.1)
+    ruby-progressbar (1.10.1)
+    sawyer (0.8.2)
+      addressable (>= 2.3.5)
+      faraday (> 0.8, < 2.0)
+    unicode-display_width (1.7.0)
+    yard (0.9.25)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  bundler
+  byebug
+  oktakit!
+  rake
+  rspec (~> 3.2)
+  rubocop
+  vcr (~> 2.9)!
+  yard
+
+BUNDLED WITH
+   2.1.4

--- a/README.md
+++ b/README.md
@@ -25,15 +25,30 @@ $ bundle
 
 `Oktakit` follows similar patterns as found in [`Octokit`](https://github.com/octokit/octokit.rb). So if you are familiar with Oktakit, then you should feel right at home.
 
-```ruby
-client = Oktakit.new(token: 't0k3n', organization: 'my-great-org')
-response, http_status = client.list_users
-```
-
-To work with the Okta sandbox (`<organization>.oktapreview.com`), set the `api_endpoint`:
+To work with the Okta sandbox environments (e.g. `<organization>.oktapreview.com`), set the `api_endpoint`:
 
 ```ruby
 client = Oktakit.new(token: 't0k3n', api_endpoint: 'https://my-great-org.oktapreview.com/api/v1')
+```
+
+For regular okta environments, you can use `organization`:
+
+```ruby
+client = Oktakit.new(token: 't0k3n', organization: 'my-great-org')
+```
+
+The return values of each method are tuples, containing the body of the
+response, and the status code.
+
+```ruby
+response, http_status = client.list_users
+```
+
+To analyze the last response, you can call `.last_response`:
+
+```ruby
+response = client.last_response
+headers = response.headers
 ```
 
 #### Pagination
@@ -51,8 +66,3 @@ Thanks for showing interest in contributing! Please read the [Contributing
 Guide](https://github.com/hectron/oktakit/blob/main/.github/CONTRIBUTING.md) before
 submitting a pull request.
 
-1. Fork it ( https://github.com/shopify/oktakit/fork )
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Add some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request

--- a/README.md
+++ b/README.md
@@ -4,18 +4,22 @@ Ruby toolkit for the [Okta API](http://developer.okta.com/docs/api/getting_start
 
 [![Build Status](https://secure.travis-ci.org/Shopify/oktakit.png)](http://travis-ci.org/Shopify/oktakit)
 [![Gem Version](https://badge.fury.io/rb/oktakit.png)](http://badge.fury.io/rb/oktakit)
+[![Contributor
+Covenant](https://img.shields.io/badge/Contributor%20Covenant-v2.0%20adopted-ff69b4.svg)](code_of_conduct.md)
 
 ## Installation
 
 Add this line to your application's Gemfile:
 
 ```ruby
-gem 'oktakit'
+gem 'oktakit', git: 'https://github.com/hectron/oktakit'
 ```
 
 And then execute:
 
-    $ bundle
+```bash
+$ bundle
+```
 
 ## Usage
 
@@ -33,6 +37,7 @@ client = Oktakit.new(token: 't0k3n', api_endpoint: 'https://my-great-org.oktapre
 ```
 
 #### Pagination
+
 Pass the `paginate` flag as options for any `get` action for Oktakit to autopaginate the response for you.
 
 ```ruby
@@ -40,24 +45,11 @@ client = Oktakit.new(token: 't0k3n', organization: 'my-great-org')
 response, http_status = client.list_users(paginate: true)
 ```
 
-## Development
-
-After checking out the repo, run `bin/setup` to install dependencies. Then, run `bin/console` for an interactive prompt that will allow you to experiment.
-
-To install this gem onto your local machine, run `bundle exec rake install`. To release a new version, update the version number in `version.rb`, and then run `bundle exec rake release` to create a git tag for the version, push git commits and tags, and push the `.gem` file to [rubygems.org](https://rubygems.org).
-
-## Testing
-
-Testing is fairly straightforward, with the exception of the org URL.
-To anonymize the VCR data, first setup a real token and endpoint for Okta, such as `myokta.okta.com`
-
-- In `spec_helper.rb`, set the org to `my-okta` (or whatever your organization is).
-- Set the `OKTA_TEST_TOKEN` environment variable (this should be real). Don't worry, it is automatically removed.
-- Before committing, change `my-okta` to `okta-test` in `spec_helper.rb` and any VCR Cassettes.
-
-The [API Test Client](https://developer.okta.com/docs/api/getting_started/api_test_client) provided by Okta is also really helpful.
-
 ## Contributing
+
+Thanks for showing interest in contributing! Please read the [Contributing
+Guide](https://github.com/hectron/oktakit/blob/main/.github/CONTRIBUTING.md) before
+submitting a pull request.
 
 1. Fork it ( https://github.com/shopify/oktakit/fork )
 2. Create your feature branch (`git checkout -b my-new-feature`)

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -144,6 +144,21 @@ module Oktakit
       def list_assigned_applications(id, options = {})
         get("/groups/#{id}/apps", options)
       end
+
+      # Add Group Rule
+      #
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Hash<Sawyer::Resource>] The created Group Rule.
+      # @see http://developer.okta.com/docs/api/resources/groups.html#create-group-rule
+      # @example
+      #   Oktakit.add_group_rule
+      def add_group_rule(options = {})
+        post('/groups/rules', options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -190,6 +190,22 @@ module Oktakit
       def list_group_rules(options = {})
         get('/groups/rules', options)
       end
+
+      # Get Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Hash<Sawyer::Resource>] Fetched Group Rule
+      # @see http://developer.okta.com/docs/api/resources/groups.html#get-group-rule
+      # @example
+      #   Oktakit.get_group_rule('id')
+      def get_group_rule(id, options = {})
+        get("/groups/rules/#{id}", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -222,6 +222,22 @@ module Oktakit
       def activate_group_rule(id, options = {})
         post("/groups/rules/#{id}/lifecycle/activate", options)
       end
+
+      # Deactivate Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return  HTTP 204 No Content
+      # @see http://developer.okta.com/docs/api/resources/groups.html#deactivate-a-group-rule
+      # @example
+      #   Oktakit.deactivate_group_rule('id')
+      def deactivate_group_rule(id, options = {})
+        post("/groups/rules/#{id}/lifecycle/deactivate", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -159,6 +159,22 @@ module Oktakit
       def add_group_rule(options = {})
         post('/groups/rules', options)
       end
+
+      # Update Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Hash<Sawyer::Resource>] Updated Group Rule
+      # @see http://developer.okta.com/docs/api/resources/groups.html#update-group-rule
+      # @example
+      #   Oktakit.update_group('id')
+      def update_group_rule(id, options = {})
+        put("/groups/rules/#{id}", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -238,6 +238,22 @@ module Oktakit
       def deactivate_group_rule(id, options = {})
         post("/groups/rules/#{id}/lifecycle/deactivate", options)
       end
+
+      # Delete Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return  HTTP 202 Accepted
+      # @see http://developer.okta.com/docs/api/resources/groups.html#delete-a-group-rule
+      # @example
+      #   Oktakit.delete_group_rule('id')
+      def delete_group_rule(id, options = {})
+        delete("/groups/rules/#{id}", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -206,6 +206,22 @@ module Oktakit
       def get_group_rule(id, options = {})
         get("/groups/rules/#{id}", options)
       end
+
+      # Activate Group Rule
+      #
+      # @params id [string] Group Rule ID
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return  HTTP 204 No Content
+      # @see http://developer.okta.com/docs/api/resources/groups.html#activate-a-group-rule
+      # @example
+      #   Oktakit.activate_group_rule('id')
+      def activate_group_rule(id, options = {})
+        post("/groups/rules/#{id}/lifecycle/activate", options)
+      end
     end
   end
 end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -175,6 +175,21 @@ module Oktakit
       def update_group_rule(id, options = {})
         put("/groups/rules/#{id}", options)
       end
+
+      # List Group Rules
+      #
+      # @param options[:query] [Hash] Optional. Query params for request
+      # @param options[:headers] [Hash] Optional. Header params for the request.
+      # @param options[:accept] [String] Optional. The content type to accept. Default application/json
+      # @param options[:content_type] [String] Optional. The content type for the request. Default application/json
+      # @param options [Hash] Optional. Body params for request.
+      # @return [Array<Sawyer::Resource>] Array of Groups Rules
+      # @see http://developer.okta.com/docs/api/resources/groups.html#list-groups-rules
+      # @example
+      #   Oktakit.list_group_rules
+      def list_group_rules(options = {})
+        get('/groups/rules', options)
+      end
     end
   end
 end

--- a/lib/oktakit/error.rb
+++ b/lib/oktakit/error.rb
@@ -41,7 +41,7 @@ module Oktakit
     # Array of validation errors
     # @return [Array<Hash>] Error info
     def errors
-      if data && data.is_a?(Hash)
+      if data&.is_a?(Hash)
         data[:errors] || []
       else
         []

--- a/oktakit.gemspec
+++ b/oktakit.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '>= 2.2'
+  spec.required_ruby_version = '>= 2.4'
 
   spec.add_dependency 'sawyer', '~> 0.8.1'
   spec.add_development_dependency 'bundler'

--- a/spec/cassettes/activate_group_rule.yml
+++ b/spec/cassettes/activate_group_rule.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7/lifecycle/activate
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 204
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:14:36 GMT
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      x-okta-request-id:
+      - Xa5J7GmsouxLEYfTWLAN5QAAFUI
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571703336'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-frame-options:
+      - SAMEORIGIN
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=3ECAC11AAB32FBC011CDC45CC3C56CD0;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:14:32 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/add_group_rule.yml
+++ b/spec/cassettes/add_group_rule.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://okta-test.okta.com/api/v1/groups/rules
+    body:
+      encoding: UTF-8
+      string: '{"name":"New Group Rule","type":"group_rule","conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}}}'
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 21 Oct 2019 23:43:20 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - Xa5CmNXJtAtvPoJxfwPXAgAADB8
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571701460'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=11811A0C3056C53B49C2D9C7570B9A49;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"type":"group_rule","id":"0prnztlu4bzSqZ2vG0h7","status":"INACTIVE","name":"New
+        Group Rule","created":"2019-10-21T23:43:20.000Z","lastUpdated":"2019-10-21T23:43:20.000Z","conditions":{"expression":{"value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}},"allGroupsValid":true}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 23:43:16 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/deactivate_group_rule.yml
+++ b/spec/cassettes/deactivate_group_rule.yml
@@ -1,0 +1,63 @@
+---
+http_interactions:
+- request:
+    method: post
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7/lifecycle/deactivate
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 204
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:20:05 GMT
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      x-okta-request-id:
+      - Xa5LNWUwbv163EGaFsEKGwAAD6I
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571703665'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-frame-options:
+      - SAMEORIGIN
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=60C7C5774D58F58504017C60C978C663;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: ''
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:20:01 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/delete_group_rule.yml
+++ b/spec/cassettes/delete_group_rule.yml
@@ -1,0 +1,65 @@
+---
+http_interactions:
+- request:
+    method: delete
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7
+    body:
+      encoding: UTF-8
+      string: "{}"
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 202
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:23:20 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      x-okta-request-id:
+      - Xa5L@DPyhtXiO0aIv6azHAAAClU
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571703860'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=68EB5A5CE1BD7B598BA90CACA2D330BE;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: "{}"
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:23:17 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/get_group_rule.yml
+++ b/spec/cassettes/get_group_rule.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:10:40 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - Xa5JAA8k6jCS0MKkufPZ8AAAE6c
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571703100'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=1CF3938F271486BDFE1C0418235993D2;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"type":"group_rule","id":"0prnztlu4bzSqZ2vG0h7","status":"INACTIVE","name":"A
+        New Group Rule","created":"2019-10-21T23:43:20.000Z","lastUpdated":"2019-10-21T23:57:49.000Z","conditions":{"expression":{"value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}},"allGroupsValid":true}'
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:10:36 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/list_group_rules.yml
+++ b/spec/cassettes/list_group_rules.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://okta-test.okta.com/api/v1/groups/rules
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Tue, 22 Oct 2019 00:01:50 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - Xa5G7lTOOSfcIa2PfBdtTgAAEj8
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '499'
+      x-rate-limit-reset:
+      - '1571702570'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=C699FF50BF0527D17510A0A000B0BEB1;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '[{"type":"group_rule","id":"0prnztlu4bzSqZ2vG0h7","status":"INACTIVE","name":"A
+        New Group Rule","created":"2019-10-21T23:43:20.000Z","lastUpdated":"2019-10-21T23:57:49.000Z","conditions":{"expression":{"value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}},"allGroupsValid":true}]'
+    http_version: 
+  recorded_at: Tue, 22 Oct 2019 00:01:46 GMT
+recorded_with: VCR 2.9.3

--- a/spec/cassettes/update_group_rule.yml
+++ b/spec/cassettes/update_group_rule.yml
@@ -1,0 +1,70 @@
+---
+http_interactions:
+- request:
+    method: put
+    uri: https://okta-test.okta.com/api/v1/groups/rules/0prnztlu4bzSqZ2vG0h7
+    body:
+      encoding: UTF-8
+      string: '{"name":"A New Group Rule","type":"group_rule","conditions":{"expression":{"type":"urn:okta:expression:1.0","value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}}}'
+    headers:
+      User-Agent:
+      - Oktakit v0.2.0
+      Accept:
+      - application/json
+      Content-Type:
+      - application/json
+      Authorization:
+      - SSWS  <<ACCESS_TOKEN>>
+  response:
+    status:
+      code: 200
+      message: 
+    headers:
+      date:
+      - Mon, 21 Oct 2019 23:57:49 GMT
+      content-type:
+      - application/json;charset=UTF-8
+      transfer-encoding:
+      - chunked
+      connection:
+      - close
+      server:
+      - nginx
+      public-key-pins-report-only:
+      - pin-sha256="jZomPEBSDXoipA9un78hKRIeN/+U4ZteRaiX8YpWfqc="; pin-sha256="axSbM6RQ+19oXxudaOTdwXJbSr6f7AahxbDHFy3p8s8=";
+        pin-sha256="SE4qe2vdD9tAegPwO79rMnZyhHvqj3i5g1c2HkyGUNE="; pin-sha256="ylP0lMLMvBaiHn0ihLxHjzvlPVQNoyQ+rMiaj0da/Pw=";
+        max-age=60; report-uri="https://okta.report-uri.io/r/default/hpkp/reportOnly"
+      vary:
+      - Accept-Encoding
+      x-okta-request-id:
+      - Xa5F-QU-bmF1Sa4VfDegxwAADxw
+      x-xss-protection:
+      - 1; mode=block; report=https://oktadev.report-uri.com/r/d/xss/enforce
+      p3p:
+      - CP="HONK"
+      x-rate-limit-limit:
+      - '500'
+      x-rate-limit-remaining:
+      - '498'
+      x-rate-limit-reset:
+      - '1571702284'
+      cache-control:
+      - no-cache, no-store
+      pragma:
+      - no-cache
+      expires:
+      - '0'
+      x-content-type-options:
+      - nosniff
+      strict-transport-security:
+      - max-age=315360000
+      set-cookie:
+      - sid=""; Expires=Thu, 01-Jan-1970 00:00:10 GMT; Path=/, JSESSIONID=A9B08B7DE7E65065737F3367F148EE76;
+        Path=/; Secure; HttpOnly
+    body:
+      encoding: UTF-8
+      string: '{"type":"group_rule","id":"0prnztlu4bzSqZ2vG0h7","status":"INACTIVE","name":"A
+        New Group Rule","created":"2019-10-21T23:43:20.000Z","lastUpdated":"2019-10-21T23:57:49.000Z","conditions":{"expression":{"value":"isMemberOfAnyGroup(\"00gj57nf29Hb16yys0h7\")","type":"urn:okta:expression:1.0"}},"actions":{"assignUserToGroups":{"groupIds":["00gnztfrp0uIKGEf80h7"]}},"allGroupsValid":true}'
+    http_version: 
+  recorded_at: Mon, 21 Oct 2019 23:57:45 GMT
+recorded_with: VCR 2.9.3

--- a/spec/client/apps_spec.rb
+++ b/spec/client/apps_spec.rb
@@ -40,8 +40,8 @@ describe Oktakit::Client::Apps do
     it 'returns updated application' do
       VCR.use_cassette 'update_application', record: :new_episodes do
         resp, = client.update_application(APPS_APP_ID,
-          id: APPS_APP_ID,
-          signOnMode: "SAML_2_0")
+                                          id: APPS_APP_ID,
+                                          signOnMode: "SAML_2_0")
         expect(resp.id).to be == APPS_APP_ID
       end
     end
@@ -81,11 +81,11 @@ describe Oktakit::Client::Apps do
     it 'returns application user' do
       VCR.use_cassette 'assign_user_to_application_for_sso' do
         resp, status = client.assign_user_to_application_for_sso(APPS_APP_ID,
-          id: APPS_USER_ID,
-          scope: "USER",
-          credentials: {
-            userName: "user@example.com"
-          })
+                                                                 id: APPS_USER_ID,
+                                                                 scope: "USER",
+                                                                 credentials: {
+                                                                   userName: "user@example.com"
+                                                                 })
         expect(status).to be(200)
         expect(resp.id).to be == '00u6nm9ytbmwHeunx0h7'
       end
@@ -96,10 +96,12 @@ describe Oktakit::Client::Apps do
     it 'returns application user with user profile mappings applied' do
       VCR.use_cassette 'assign_user_to_application_for_sso_provisioning', record: :new_episodes do
         resp, status = client.assign_user_to_application_for_sso_provisioning(APPS_APP_ID,
-          id: APPS_USER_ID,
-          scope: "USER",
-          credentials: { userName: "user@example.com" },
-          profile: {})
+                                                                              id: APPS_USER_ID,
+                                                                              scope: "USER",
+                                                                              credentials: {
+                                                                                userName: "user@example.com"
+                                                                              },
+                                                                              profile: {})
         expect(status).to be(200)
         expect(resp.id).to be == '00u6nm9ytbmwHeunx0h7'
       end
@@ -128,12 +130,12 @@ describe Oktakit::Client::Apps do
     it 'returns application user' do
       VCR.use_cassette 'update_application_credentials_for_assigned_user', record: :new_episodes do
         resp, = client.update_application_credentials_for_assigned_user(APPS_APP_ID, APPS_USER_ID,
-          credentials: {
-            userName: "user@example.com",
-            password: {
-              value: "newPassword"
-            }
-          })
+                                                                        credentials: {
+                                                                          userName: "user@example.com",
+                                                                          password: {
+                                                                            value: "newPassword"
+                                                                          }
+                                                                        })
         expect(resp.id).to be == '00u6nm9ytbmwHeunx0h7'
       end
     end

--- a/spec/client/factors_spec.rb
+++ b/spec/client/factors_spec.rb
@@ -45,11 +45,11 @@ describe Oktakit::Client::Factors do
     it 'returns all responses return the enrolled factor with a status of either pending_activation or active.' do
       VCR.use_cassette 'enroll_factor', record: :new_episodes do
         resp, = client.enroll_factor(FACTORS_USER_ID,
-          factorType: "sms",
-          provider: "OKTA",
-          profile: {
-            phoneNumber: "+1-613-456-1234"
-          })
+                                     factorType: "sms",
+                                     provider: "OKTA",
+                                     profile: {
+                                       phoneNumber: "+1-613-456-1234"
+                                     })
         expect(resp.id).not_to be_nil
       end
     end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -178,4 +178,15 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#deactivate_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    it 'deactivates a group rule' do
+      VCR.use_cassette 'deactivate_group_rule' do
+        _, status = client.deactivate_group_rule(group_rule_id)
+        expect(status).to eq(204)
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -2,14 +2,14 @@ require 'spec_helper'
 
 describe Oktakit::Client::Groups do
   GROUPS_GROUP_ID = '00g6o0uh8xcL5WbyZ0h7'
-  GROUPS_USER_ID = '00u6nm9ytbmwHeunx0h7'
+  GROUPS_USER_ID  = '00u6nm9ytbmwHeunx0h7'
 
   describe '#add_group' do
     it 'returns the created group.' do
       VCR.use_cassette 'add_group' do
         resp, = client.add_group(
           profile: {
-            name: "New Group Users",
+            name:        "New Group Users",
             description: "New Group Users"
           }
         )
@@ -41,7 +41,7 @@ describe Oktakit::Client::Groups do
       VCR.use_cassette 'update_group' do
         resp, = client.update_group(GROUPS_GROUP_ID,
                                     profile: {
-                                      name: "New Name for the Group",
+                                      name:        "New Name for the Group",
                                       description: "New Name for the Group"
                                     })
         expect(resp.profile.name).to be == "New Name for the Group"
@@ -153,6 +153,17 @@ describe Oktakit::Client::Groups do
       VCR.use_cassette 'list_group_rules' do
         resp, = client.list_group_rules
         expect(resp).to be_a(Array)
+      end
+    end
+  end
+
+  describe '#get_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    it 'returns a group rule' do
+      VCR.use_cassette 'get_group_rule' do
+        resp, = client.get_group_rule(group_rule_id)
+        expect(resp.id).not_to be_nil
       end
     end
   end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -147,4 +147,13 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#list_group_rules' do
+    it 'returns an array of group rules' do
+      VCR.use_cassette 'list_group_rules' do
+        resp, = client.list_group_rules
+        expect(resp).to be_a(Array)
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -93,4 +93,30 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#add_group_rule' do
+    let(:member_of_group_id) { '00gj57nf29Hb16yys0h7' }
+    let(:group_ids_to_assign) { ['00gnztfrp0uIKGEf80h7'] }
+
+    it 'returns the create group rule' do
+      VCR.use_cassette 'add_group_rule' do
+        resp, = client.add_group_rule(
+          name:       'New Group Rule',
+          type:       'group_rule',
+          conditions: {
+            expression: {
+              type:  'urn:okta:expression:1.0',
+              value: "isMemberOfAnyGroup(\"#{member_of_group_id}\")"
+            }
+          },
+          actions:    {
+            assignUserToGroups: {
+              groupIds: group_ids_to_assign
+            }
+          })
+
+        expect(resp.id).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -42,7 +42,7 @@ describe Oktakit::Client::Groups do
       VCR.use_cassette 'update_group' do
         resp, = client.update_group(GROUPS_GROUP_ID,
                                     profile: {
-                                      name:        "New Name for the Group",
+                                      name: "New Name for the Group",
                                       description: "New Name for the Group"
                                     })
         expect(resp.profile.name).to be == "New Name for the Group"
@@ -102,19 +102,20 @@ describe Oktakit::Client::Groups do
     it 'returns the create group rule' do
       VCR.use_cassette 'add_group_rule' do
         resp, = client.add_group_rule(
-          name:       'New Group Rule',
-          type:       'group_rule',
+          name: 'New Group Rule',
+          type: 'group_rule',
           conditions: {
             expression: {
-              type:  'urn:okta:expression:1.0',
+              type: 'urn:okta:expression:1.0',
               value: "isMemberOfAnyGroup(\"#{member_of_group_id}\")"
             }
           },
-          actions:    {
+          actions: {
             assignUserToGroups: {
               groupIds: group_ids_to_assign
             }
-          })
+          }
+        )
 
         expect(resp.id).not_to be_nil
       end
@@ -128,15 +129,15 @@ describe Oktakit::Client::Groups do
     it 'returns the updated group rule' do
       VCR.use_cassette 'update_group_rule' do
         resp, = client.update_group_rule(group_rule_id,
-                                         name:       'A New Group Rule',
-                                         type:       'group_rule',
+                                         name: 'A New Group Rule',
+                                         type: 'group_rule',
                                          conditions: {
                                            expression: {
-                                             type:  'urn:okta:expression:1.0',
+                                             type: 'urn:okta:expression:1.0',
                                              value: "isMemberOfAnyGroup(\"#{member_of_group_id}\")"
                                            }
                                          },
-                                         actions:    {
+                                         actions: {
                                            assignUserToGroups: {
                                              groupIds: group_ids_to_assign
                                            }

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 describe Oktakit::Client::Groups do
   GROUPS_GROUP_ID = '00g6o0uh8xcL5WbyZ0h7'
   GROUPS_USER_ID  = '00u6nm9ytbmwHeunx0h7'
+  let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
 
   describe '#add_group' do
     it 'returns the created group.' do
@@ -121,8 +122,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#update_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     let(:member_of_group_id) { '00gj57nf29Hb16yys0h7' }
     let(:group_ids_to_assign) { ['00gnztfrp0uIKGEf80h7'] }
 
@@ -158,8 +157,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#get_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     it 'returns a group rule' do
       VCR.use_cassette 'get_group_rule' do
         resp, = client.get_group_rule(group_rule_id)
@@ -169,8 +166,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#activate_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     it 'activates a group rule' do
       VCR.use_cassette 'activate_group_rule' do
         _, status = client.activate_group_rule(group_rule_id)
@@ -180,8 +175,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#deactivate_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     it 'deactivates a group rule' do
       VCR.use_cassette 'deactivate_group_rule' do
         _, status = client.deactivate_group_rule(group_rule_id)
@@ -191,8 +184,6 @@ describe Oktakit::Client::Groups do
   end
 
   describe '#delete_group_rule' do
-    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
-
     it 'deletes the group rule' do
       VCR.use_cassette 'delete_group_rule' do
         _, status = client.delete_group_rule(group_rule_id)

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -167,4 +167,15 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#activate_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    it 'activates a group rule' do
+      VCR.use_cassette 'activate_group_rule' do
+        _, status = client.activate_group_rule(group_rule_id)
+        expect(status).to eq(204)
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -189,4 +189,15 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#delete_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    it 'deletes the group rule' do
+      VCR.use_cassette 'delete_group_rule' do
+        _, status = client.delete_group_rule(group_rule_id)
+        expect(status).to eq(202)
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -40,10 +40,10 @@ describe Oktakit::Client::Groups do
     it 'returns updated group' do
       VCR.use_cassette 'update_group' do
         resp, = client.update_group(GROUPS_GROUP_ID,
-          profile: {
-            name: "New Name for the Group",
-            description: "New Name for the Group"
-          })
+                                    profile: {
+                                      name: "New Name for the Group",
+                                      description: "New Name for the Group"
+                                    })
         expect(resp.profile.name).to be == "New Name for the Group"
       end
     end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -119,4 +119,32 @@ describe Oktakit::Client::Groups do
       end
     end
   end
+
+  describe '#update_group_rule' do
+    let(:group_rule_id) { '0prnztlu4bzSqZ2vG0h7' }
+
+    let(:member_of_group_id) { '00gj57nf29Hb16yys0h7' }
+    let(:group_ids_to_assign) { ['00gnztfrp0uIKGEf80h7'] }
+
+    it 'returns the updated group rule' do
+      VCR.use_cassette 'update_group_rule' do
+        resp, = client.update_group_rule(group_rule_id,
+                                         name:       'A New Group Rule',
+                                         type:       'group_rule',
+                                         conditions: {
+                                           expression: {
+                                             type:  'urn:okta:expression:1.0',
+                                             value: "isMemberOfAnyGroup(\"#{member_of_group_id}\")"
+                                           }
+                                         },
+                                         actions:    {
+                                           assignUserToGroups: {
+                                             groupIds: group_ids_to_assign
+                                           }
+                                         })
+
+        expect(resp.id).not_to be_nil
+      end
+    end
+  end
 end

--- a/spec/client/groups_spec.rb
+++ b/spec/client/groups_spec.rb
@@ -10,7 +10,7 @@ describe Oktakit::Client::Groups do
       VCR.use_cassette 'add_group' do
         resp, = client.add_group(
           profile: {
-            name:        "New Group Users",
+            name: "New Group Users",
             description: "New Group Users"
           }
         )

--- a/spec/client/identity_providers_spec.rb
+++ b/spec/client/identity_providers_spec.rb
@@ -95,7 +95,7 @@ describe Oktakit::Client::IdentityProviders do
   describe '#update_identity_provider' do
     it 'returns updated identity provider' do
       VCR.use_cassette 'update_identity_provider', record: :new_episodes do
-        _, status = client.update_identity_provider(IDENTITY_PROVIDERS_IDENTITY_ID,
+        payload = {
           id: "0oa62bfdjnK55Z5x80h7",
           type: "SAML2",
           name: "Example IdP",
@@ -158,7 +158,9 @@ describe Oktakit::Client::IdentityProviders do
               matchType: "USERNAME"
             },
             maxClockSkew: 120000
-          })
+          }
+        }
+        _, status = client.update_identity_provider(IDENTITY_PROVIDERS_IDENTITY_ID, payload)
         expect(status).to be(200)
       end
     end
@@ -240,9 +242,9 @@ describe Oktakit::Client::IdentityProviders do
     it 'returns identity provider transaction' do
       VCR.use_cassette 'link_idp_user', record: :new_episodes do
         resp, = client.link_idp_user(IDENTITY_PROVIDERS_TRANSACTION_ID, IDENTITY_PROVIDERS_USER_ID,
-          profile: {
-            userType: "Social"
-          })
+                                     profile: {
+                                       userType: "Social"
+                                     })
         expect(resp.id).not_to be_nil
       end
     end

--- a/spec/client/templates_spec.rb
+++ b/spec/client/templates_spec.rb
@@ -44,15 +44,15 @@ describe Oktakit::Client::Templates do
     it 'returns updated sms template' do
       VCR.use_cassette 'update_sms_template' do
         _, status = client.update_sms_template(TEMPLATES_TEMPLATE_ID,
-          name: "Custom",
-          type: "SMS_VERIFY_CODE",
-          template: "Your ${org.name} code is: ${code}",
-          translations:
-          {
-            es: "${org.name}: ${code}.",
-            fr: "${org.name}: ${code}.",
-            it: "${org.name}: ${code}."
-          })
+                                               name: "Custom",
+                                               type: "SMS_VERIFY_CODE",
+                                               template: "Your ${org.name} code is: ${code}",
+                                               translations:
+                                               {
+                                                 es: "${org.name}: ${code}.",
+                                                 fr: "${org.name}: ${code}.",
+                                                 it: "${org.name}: ${code}."
+                                               })
         expect(status).to be(200)
       end
     end
@@ -62,9 +62,9 @@ describe Oktakit::Client::Templates do
     it 'returns updated sms template' do
       VCR.use_cassette 'partial_sms_template_update' do
         resp, = client.partial_sms_template_update(TEMPLATES_TEMPLATE_ID,
-          translations: {
-            de: "${org.name}: ihre bestätigungscode ist ${code}."
-          })
+                                                   translations: {
+                                                     de: "${org.name}: ihre bestätigungscode ist ${code}."
+                                                   })
         expect(resp.translations.de).to be == '${org.name}: ihre bestätigungscode ist ${code}.'
       end
     end

--- a/spec/client/users_spec.rb
+++ b/spec/client/users_spec.rb
@@ -52,12 +52,12 @@ describe Oktakit::Client::Users do
     it 'returns updated user' do
       VCR.use_cassette 'update_user' do
         resp, = client.update_user(USERS_USER_ID,
-          profile: {
-            firstName: "Bob",
-            lastName: "User",
-            email: "example@example.com",
-            login: "example@example.com"
-          })
+                                   profile: {
+                                     firstName: "Bob",
+                                     lastName: "User",
+                                     email: "example@example.com",
+                                     login: "example@example.com"
+                                   })
         expect(resp.profile.firstName).to be == 'Bob'
       end
     end
@@ -67,13 +67,13 @@ describe Oktakit::Client::Users do
     it 'returns updated user' do
       VCR.use_cassette 'update_user_partial' do
         resp, = client.update_user(USERS_USER_ID,
-          profile: {
-            firstName: "Bob",
-            lastName: "User",
-            email: "example@example.com",
-            login: "example@example.com"
-          },
-          partial: true)
+                                   profile: {
+                                     firstName: "Bob",
+                                     lastName: "User",
+                                     email: "example@example.com",
+                                     login: "example@example.com"
+                                   },
+                                   partial: true)
         expect(resp.profile.firstName).to be == 'Bob'
       end
     end
@@ -83,12 +83,12 @@ describe Oktakit::Client::Users do
     it 'returns updated user' do
       VCR.use_cassette 'update_profile' do
         resp, = client.update_profile(USERS_USER_ID,
-          profile: {
-            firstName: "Other Bob",
-            lastName: "User",
-            email: "example@example.com",
-            login: "example@example.com"
-          })
+                                      profile: {
+                                        firstName: "Other Bob",
+                                        lastName: "User",
+                                        email: "example@example.com",
+                                        login: "example@example.com"
+                                      })
         expect(resp.profile.firstName).to be == 'Other Bob'
       end
     end
@@ -188,8 +188,10 @@ describe Oktakit::Client::Users do
     it 'returns an empty object by default.' do
       VCR.use_cassette 'forgot_password' do
         resp, = client.forgot_password(USERS_USER_ID,
-          password: { value: "123Password!" },
-          recovery_question: { answer: "A woodchuck could chuck as much as he could chuck." })
+                                       password: { value: "123Password!" },
+                                       recovery_question: {
+                                         answer: "A woodchuck could chuck as much as he could chuck."
+                                       })
         expect(resp.password.to_h).to be == {}
       end
     end
@@ -199,8 +201,8 @@ describe Oktakit::Client::Users do
     it 'returns credentials of the user' do
       VCR.use_cassette 'change_password' do
         _, status = client.change_password(USERS_USER_ID,
-          oldPassword: { value: "uTVM,TPw55" },
-          newPassword: { value: "NewPassword1234!" })
+                                           oldPassword: { value: "uTVM,TPw55" },
+                                           newPassword: { value: "NewPassword1234!" })
         expect(status).to be(200)
       end
     end
@@ -210,11 +212,11 @@ describe Oktakit::Client::Users do
     it 'returns credentials of the user' do
       VCR.use_cassette 'change_recovery_question' do
         resp, = client.change_recovery_question(USERS_USER_ID,
-          password: { value: "NewPassword1234!" },
-          recovery_question: {
-            question: "Where is Shopify's HQ?",
-            answer: "Ottawa"
-          })
+                                                password: { value: "NewPassword1234!" },
+                                                recovery_question: {
+                                                  question: "Where is Shopify's HQ?",
+                                                  answer: "Ottawa"
+                                                })
         expect(resp.recovery_question.question).to be == "Where is Shopify's HQ?"
       end
     end

--- a/spec/pagination_spec.rb
+++ b/spec/pagination_spec.rb
@@ -14,7 +14,8 @@ describe Oktakit do
   it 'should send query parameters in each page request' do
     VCR.use_cassette 'pagination_with_query_params' do
       users, = client.list_users_assigned_to_application(PAGED_APPS_APP_ID,
-        paginate: true, query: { expand: 'user', limit: '1' })
+                                                         paginate: true,
+                                                         query: { expand: 'user', limit: '1' })
       users.each do |user|
         expect(user._embedded).not_to be_nil, "User #{user.id} was expected to have expanded user profile in _embedded"
       end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,7 +32,7 @@ require 'oktakit'
 module TestClient
   extend RSpec::SharedContext
   let(:client) do
-    Oktakit::Client.new(token:        test_okta_token,
+    Oktakit::Client.new(token: test_okta_token,
                         organization: test_okta_organization,
                         api_endpoint: test_okta_api_endpoint)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -31,7 +31,11 @@ require 'oktakit'
 
 module TestClient
   extend RSpec::SharedContext
-  let(:client) { Oktakit::Client.new(token: test_okta_token, organization: 'okta-test') }
+  let(:client) do
+    Oktakit::Client.new(token:        test_okta_token,
+                        organization: test_okta_organization,
+                        api_endpoint: test_okta_api_endpoint)
+  end
 end
 
 RSpec.configure do |config|
@@ -40,4 +44,12 @@ end
 
 def test_okta_token
   ENV.fetch('OKTA_TEST_TOKEN', 'x' * 40)
+end
+
+def test_okta_organization
+  ENV.fetch('OKTA_TEST_ORGANIZATION', 'okta-test')
+end
+
+def test_okta_api_endpoint
+  ENV['OKTA_TEST_API_ENDPOINT']
 end


### PR DESCRIPTION
## Problem

The Okta API supports [group rules](https://developer.okta.com/docs/reference/api/groups/#group-rule-operations), but the client is missing them.
 
## Proposal

- Add the group rule endpoints

###  Other fixes

The spec helper didn't have a way to mock which server to communicate to. I don't have access to `okta-test.okta.com`, so I used environment variables to talk to my instance of Okta.