### PR TITLE
Let Sawyer handle the base URL

### DIFF
--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -169,7 +169,7 @@ module Oktakit
       options[:headers][:accept] = accept if accept
       options[:headers][:content_type] = content_type if content_type
 
-      uri = URI::DEFAULT_PARSER.escape("/api/v1" + path.to_s)
+      uri = URI::DEFAULT_PARSER.escape(path.to_s)
       @last_response = resp = sawyer_agent.call(method, uri, data, options)
 
       response = [resp.data, resp.status]
@@ -196,7 +196,7 @@ module Oktakit
     def absolute_to_relative_url(next_ref)
       return unless next_ref
 
-      next_ref.href.sub(api_endpoint, '')
+      next_ref.href.sub(api_endpoint + '/', '')
     end
   end
 end

--- a/lib/oktakit/client/admin_roles.rb
+++ b/lib/oktakit/client/admin_roles.rb
@@ -14,7 +14,7 @@ module Oktakit
       # @example
       #   Oktakit.list_roles_assigned_to_user('id')
       def list_roles_assigned_to_user(id, options = {})
-        get("/users/#{id}/roles", options)
+        get("users/#{id}/roles", options)
       end
 
       # Assign Role to User
@@ -30,7 +30,7 @@ module Oktakit
       # @example
       #   Oktakit.assign_role_to_user('id')
       def assign_role_to_user(id, options = {})
-        post("/users/#{id}/roles", options)
+        post("users/#{id}/roles", options)
       end
 
       # Unassign Role from User
@@ -47,7 +47,7 @@ module Oktakit
       # @example
       #   Oktakit.unassign_role_from_user('user_id', 'role_id')
       def unassign_role_from_user(user_id, role_id, options = {})
-        delete("/users/#{user_id}/roles/#{role_id}", options)
+        delete("users/#{user_id}/roles/#{role_id}", options)
       end
 
       # List Group Targets for User Admin Role
@@ -64,7 +64,7 @@ module Oktakit
       # @example
       #   Oktakit.list_group_targets_for_user_admin_role('user_id', 'role_id')
       def list_group_targets_for_user_admin_role(user_id, role_id, options = {})
-        get("/users/#{user_id}/roles/#{role_id}/targets/groups", options)
+        get("users/#{user_id}/roles/#{role_id}/targets/groups", options)
       end
 
       # Add Group Target to User Admin Role
@@ -82,7 +82,7 @@ module Oktakit
       # @example
       #   Oktakit.add_group_target_to_user_admin_role('group_id', 'user_id', 'role_id')
       def add_group_target_to_user_admin_role(user_id, role_id, group_id, options = {})
-        put("/users/#{user_id}/roles/#{role_id}/targets/groups/#{group_id}", options)
+        put("users/#{user_id}/roles/#{role_id}/targets/groups/#{group_id}", options)
       end
 
       # Remove Group Target from User Admin Role
@@ -100,7 +100,7 @@ module Oktakit
       # @example
       #   Oktakit.remove_group_target_from_user_admin_role('group_id', 'user_id', 'role_id')
       def remove_group_target_from_user_admin_role(user_id, role_id, group_id, options = {})
-        delete("/users/#{user_id}/roles/#{role_id}/targets/groups/#{group_id}", options)
+        delete("users/#{user_id}/roles/#{role_id}/targets/groups/#{group_id}", options)
       end
 
       # List App Targets for App Admin Role
@@ -117,7 +117,7 @@ module Oktakit
       # @example
       #   Oktakit.list_app_targets_for_app_admin_role('user_id', 'role_id')
       def list_app_targets_for_app_admin_role(user_id, role_id, options = {})
-        get("/users/#{user_id}/roles/#{role_id}/targets/catalog/apps", options)
+        get("users/#{user_id}/roles/#{role_id}/targets/catalog/apps", options)
       end
 
       # Add App Target to App Admin Role
@@ -135,7 +135,7 @@ module Oktakit
       # @example
       #   Oktakit.add_app_target_to_app_admin_role('user_id', 'role_id')
       def add_app_target_to_app_admin_role(user_id, role_id, app_name, options = {})
-        put("/users/#{user_id}/roles/#{role_id}/targets/catalog/apps/#{app_name}", options)
+        put("users/#{user_id}/roles/#{role_id}/targets/catalog/apps/#{app_name}", options)
       end
 
       # Remove App Target from App Admin Role
@@ -153,7 +153,7 @@ module Oktakit
       # @example
       #   Oktakit.remove_app_target_from_app_admin_role('user_id', 'role_id')
       def remove_app_target_from_app_admin_role(user_id, role_id, app_name, options = {})
-        delete("/users/#{user_id}/roles/#{role_id}/targets/catalog/apps/#{app_name}", options)
+        delete("users/#{user_id}/roles/#{role_id}/targets/catalog/apps/#{app_name}", options)
       end
     end
   end

--- a/lib/oktakit/client/apps.rb
+++ b/lib/oktakit/client/apps.rb
@@ -13,7 +13,7 @@ module Oktakit
       # @example
       #   Oktakit.add_application
       def add_application(options = {})
-        post('/apps', options)
+        post('apps', options)
       end
 
       # Get Application
@@ -29,7 +29,7 @@ module Oktakit
       # @example
       #   Oktakit.get_application('id')
       def get_application(id, options = {})
-        get("/apps/#{id}", options)
+        get("apps/#{id}", options)
       end
 
       # List Applications
@@ -44,7 +44,7 @@ module Oktakit
       # @example
       #   Oktakit.list_applications
       def list_applications(options = {})
-        get('/apps', options)
+        get('apps', options)
       end
 
       # Update Application
@@ -60,7 +60,7 @@ module Oktakit
       # @example
       #   Oktakit.update_application('id')
       def update_application(id, options = {})
-        put("/apps/#{id}", options)
+        put("apps/#{id}", options)
       end
 
       # Delete Application
@@ -76,7 +76,7 @@ module Oktakit
       # @example
       #   Oktakit.delete_application('id')
       def delete_application(id, options = {})
-        delete("/apps/#{id}", options)
+        delete("apps/#{id}", options)
       end
 
       # Activate Application
@@ -92,7 +92,7 @@ module Oktakit
       # @example
       #   Oktakit.activate_application('id')
       def activate_application(id, options = {})
-        post("/apps/#{id}/lifecycle/activate", options)
+        post("apps/#{id}/lifecycle/activate", options)
       end
 
       # Deactivate Application
@@ -108,7 +108,7 @@ module Oktakit
       # @example
       #   Oktakit.deactivate_application('id')
       def deactivate_application(id, options = {})
-        post("/apps/#{id}/lifecycle/deactivate", options)
+        post("apps/#{id}/lifecycle/deactivate", options)
       end
 
       # Assign User to Application for SSO
@@ -124,7 +124,7 @@ module Oktakit
       # @example
       #   Oktakit.assign_user_to_application_for_sso('id')
       def assign_user_to_application_for_sso(id, options = {})
-        post("/apps/#{id}/users", options)
+        post("apps/#{id}/users", options)
       end
 
       # Assign User to Application for SSO & Provisioning
@@ -140,7 +140,7 @@ module Oktakit
       # @example
       #   Oktakit.assign_user_to_application_for_sso_provisioning('id')
       def assign_user_to_application_for_sso_provisioning(id, options = {})
-        post("/apps/#{id}/users", options)
+        post("apps/#{id}/users", options)
       end
 
       # Get Assigned User for Application
@@ -157,7 +157,7 @@ module Oktakit
       # @example
       #   Oktakit.get_assigned_user_for_application('user_id', 'app_id')
       def get_assigned_user_for_application(app_id, user_id, options = {})
-        get("/apps/#{app_id}/users/#{user_id}", options)
+        get("apps/#{app_id}/users/#{user_id}", options)
       end
 
       # List Users Assigned to Application
@@ -173,7 +173,7 @@ module Oktakit
       # @example
       #   Oktakit.list_users_assigned_to_application('id')
       def list_users_assigned_to_application(id, options = {})
-        get("/apps/#{id}/users", options)
+        get("apps/#{id}/users", options)
       end
 
       # List Applications Assigned to User
@@ -189,7 +189,7 @@ module Oktakit
       # @example
       #  Oktakit.list_applications_assigned_to_user('<user_id>')
       def list_applications_assigned_to_user(user_id, options = {})
-        get("/apps?filter=user.id+eq+\"#{user_id}\"&expand=user/#{user_id}", options)
+        get("apps?filter=user.id+eq+\"#{user_id}\"&expand=user/#{user_id}", options)
       end
 
       # Update Application Credentials for Assigned User
@@ -206,7 +206,7 @@ module Oktakit
       # @example
       #   Oktakit.update_application_credentials_for_assigned_user('user_id', 'app_id')
       def update_application_credentials_for_assigned_user(app_id, user_id, options = {})
-        post("/apps/#{app_id}/users/#{user_id}", options)
+        post("apps/#{app_id}/users/#{user_id}", options)
       end
 
       # Update Application Profile for Assigned User
@@ -223,7 +223,7 @@ module Oktakit
       # @example
       #   Oktakit.update_application_profile_for_assigned_user('user_id', 'app_id')
       def update_application_profile_for_assigned_user(app_id, user_id, options = {})
-        post("/apps/#{app_id}/users/#{user_id}", options)
+        post("apps/#{app_id}/users/#{user_id}", options)
       end
 
       # Remove User from Application
@@ -240,7 +240,7 @@ module Oktakit
       # @example
       #   Oktakit.remove_user_from_application('user_id', 'app_id')
       def remove_user_from_application(app_id, user_id, options = {})
-        delete("/apps/#{app_id}/users/#{user_id}", options)
+        delete("apps/#{app_id}/users/#{user_id}", options)
       end
 
       # Assign Group to Application
@@ -257,7 +257,7 @@ module Oktakit
       # @example
       #   Oktakit.assign_group_to_application('group_id', 'app_id')
       def assign_group_to_application(app_id, group_id, options = {})
-        put("/apps/#{app_id}/groups/#{group_id}", options)
+        put("apps/#{app_id}/groups/#{group_id}", options)
       end
 
       # Get Assigned Group for Application
@@ -274,7 +274,7 @@ module Oktakit
       # @example
       #   Oktakit.get_assigned_group_for_application('group_id', 'app_id')
       def get_assigned_group_for_application(app_id, group_id, options = {})
-        get("/apps/#{app_id}/groups/#{group_id}", options)
+        get("apps/#{app_id}/groups/#{group_id}", options)
       end
 
       # List Groups Assigned to Application
@@ -290,7 +290,7 @@ module Oktakit
       # @example
       #   Oktakit.list_groups_assigned_to_application('id')
       def list_groups_assigned_to_application(id, options = {})
-        get("/apps/#{id}/groups", options)
+        get("apps/#{id}/groups", options)
       end
 
       # Remove Group from Application
@@ -307,7 +307,7 @@ module Oktakit
       # @example
       #   Oktakit.remove_group_from_application('group_id', 'app_id')
       def remove_group_from_application(app_id, group_id, options = {})
-        delete("/apps/#{app_id}/groups/#{group_id}", options)
+        delete("apps/#{app_id}/groups/#{group_id}", options)
       end
 
       # Generate New Application Key Credential
@@ -323,7 +323,7 @@ module Oktakit
       # @example
       #   Oktakit.generate_new_application_key_credential('app_id')
       def generate_new_application_key_credential(app_id, options = {})
-        post("/apps/#{app_id}/credentials/keys/generate", options)
+        post("apps/#{app_id}/credentials/keys/generate", options)
       end
 
       # List Key Credentials for Application
@@ -339,7 +339,7 @@ module Oktakit
       # @example
       #   Oktakit.list_key_credentials_for_application('app_id')
       def list_key_credentials_for_application(app_id, options = {})
-        get("/apps/#{app_id}/credentials/keys", options)
+        get("apps/#{app_id}/credentials/keys", options)
       end
 
       # Get Key Credential for Application
@@ -356,7 +356,7 @@ module Oktakit
       # @example
       #   Oktakit.get_key_credential_for_application('app_id', 'key_id')
       def get_key_credential_for_application(app_id, key_id, options = {})
-        get("/apps/#{app_id}/credentials/keys/#{key_id}", options)
+        get("apps/#{app_id}/credentials/keys/#{key_id}", options)
       end
 
       # Preview SAML metadata for Application
@@ -372,7 +372,7 @@ module Oktakit
       # @example
       #   Oktakit.preview_saml_metadata_for_application('app_id')
       def preview_saml_metadata_for_application(app_id, options = {})
-        get("/apps/#{app_id}/sso/saml/metadata", options)
+        get("apps/#{app_id}/sso/saml/metadata", options)
       end
     end
   end

--- a/lib/oktakit/client/events.rb
+++ b/lib/oktakit/client/events.rb
@@ -13,7 +13,7 @@ module Oktakit
       # @example
       #   Oktakit.list_events
       def list_events(options = {})
-        get('/events', options)
+        get('events', options)
       end
     end
   end

--- a/lib/oktakit/client/factors.rb
+++ b/lib/oktakit/client/factors.rb
@@ -15,7 +15,7 @@ module Oktakit
       # @example
       #   Oktakit.get_factor('user_id', 'factor_id')
       def get_factor(user_id, factor_id, options = {})
-        get("/users/#{user_id}/factors/#{factor_id}", options)
+        get("users/#{user_id}/factors/#{factor_id}", options)
       end
 
       # List Enrolled Factors
@@ -31,7 +31,7 @@ module Oktakit
       # @example
       #   Oktakit.list_enrolled_factors('user_id')
       def list_enrolled_factors(user_id, options = {})
-        get("/users/#{user_id}/factors", options)
+        get("users/#{user_id}/factors", options)
       end
 
       # List Factors to Enroll
@@ -47,7 +47,7 @@ module Oktakit
       # @example
       #   Oktakit.list_factors_to_enroll('user_id')
       def list_factors_to_enroll(user_id, options = {})
-        get("/users/#{user_id}/factors/catalog", options)
+        get("users/#{user_id}/factors/catalog", options)
       end
 
       # List Security Questions
@@ -63,7 +63,7 @@ module Oktakit
       # @example
       #   Oktakit.list_security_questions('user_id')
       def list_security_questions(user_id, options = {})
-        get("/users/#{user_id}/factors/questions", options)
+        get("users/#{user_id}/factors/questions", options)
       end
 
       # Enroll Factor
@@ -79,7 +79,7 @@ module Oktakit
       # @example
       #   Oktakit.enroll_factor('id')
       def enroll_factor(user_id, options = {})
-        post("/users/#{user_id}/factors", options)
+        post("users/#{user_id}/factors", options)
       end
 
       # Activate Factor
@@ -96,7 +96,7 @@ module Oktakit
       # @example
       #   Oktakit.activate_factor('user_id', 'factor_id')
       def activate_factor(user_id, factor_id, options = {})
-        post("/users/#{user_id}/factors/#{factor_id}/lifecycle/activate", options)
+        post("users/#{user_id}/factors/#{factor_id}/lifecycle/activate", options)
       end
 
       # Reset Factor
@@ -113,7 +113,7 @@ module Oktakit
       # @example
       #   Oktakit.reset_factor('user_id', 'factor_id')
       def reset_factor(user_id, factor_id, options = {})
-        delete("/users/#{user_id}/factors/#{factor_id}", options)
+        delete("users/#{user_id}/factors/#{factor_id}", options)
       end
 
       # Verify Security Question Factor
@@ -130,7 +130,7 @@ module Oktakit
       # @example
       #   Oktakit.verify_security_question_factor('user_id', 'factor_id')
       def verify_security_question_factor(user_id, factor_id, options = {})
-        post("/users/#{user_id}/factors/#{factor_id}/verify", options)
+        post("users/#{user_id}/factors/#{factor_id}/verify", options)
       end
 
       # Verify SMS Factor
@@ -147,7 +147,7 @@ module Oktakit
       # @example
       #   Oktakit.verify_sms_factor('user_id', 'factor_id')
       def verify_sms_factor(user_id, factor_id, options = {})
-        post("/users/#{user_id}/factors/#{factor_id}/verify", options)
+        post("users/#{user_id}/factors/#{factor_id}/verify", options)
       end
 
       # Verify TOTP Factor
@@ -164,7 +164,7 @@ module Oktakit
       # @example
       #   Oktakit.verify_totp_factor('user_id', 'factor_id')
       def verify_totp_factor(user_id, factor_id, options = {})
-        post("/users/#{user_id}/factors/#{factor_id}/verify", options)
+        post("users/#{user_id}/factors/#{factor_id}/verify", options)
       end
 
       # Verify Push Factor
@@ -181,7 +181,7 @@ module Oktakit
       # @example
       #   Oktakit.verify_push_factor('user_id', 'factor_id')
       def verify_push_factor(user_id, factor_id, options = {})
-        post("/users/#{user_id}/factors/#{factor_id}/verify", options)
+        post("users/#{user_id}/factors/#{factor_id}/verify", options)
       end
 
       # Poll for Verify Transaction Completion
@@ -199,7 +199,7 @@ module Oktakit
       # @example
       #   Oktakit.poll_for_verify_transaction_completion('user_id', 'factor_id', 'transaction_id')
       def poll_for_verify_transaction_completion(user_id, factor_id, transaction_id, options = {})
-        get("/users/#{user_id}/factors/#{factor_id}/transactions/#{transaction_id}", options)
+        get("users/#{user_id}/factors/#{factor_id}/transactions/#{transaction_id}", options)
       end
 
       # Verify Token Factor
@@ -216,7 +216,7 @@ module Oktakit
       # @example
       #   Oktakit.verify_token_factor('user_id', 'factor_id')
       def verify_token_factor(user_id, factor_id, options = {})
-        post("/users/#{user_id}/factors/#{factor_id}/verify", options)
+        post("users/#{user_id}/factors/#{factor_id}/verify", options)
       end
     end
   end

--- a/lib/oktakit/client/groups.rb
+++ b/lib/oktakit/client/groups.rb
@@ -13,7 +13,7 @@ module Oktakit
       # @example
       #   Oktakit.add_group
       def add_group(options = {})
-        post('/groups', options)
+        post('groups', options)
       end
 
       # Get Group
@@ -29,7 +29,7 @@ module Oktakit
       # @example
       #   Oktakit.get_group('id')
       def get_group(id, options = {})
-        get("/groups/#{id}", options)
+        get("groups/#{id}", options)
       end
 
       # List Groups
@@ -44,7 +44,7 @@ module Oktakit
       # @example
       #   Oktakit.list_groups
       def list_groups(options = {})
-        get('/groups', options)
+        get('groups', options)
       end
 
       # Update Group
@@ -60,7 +60,7 @@ module Oktakit
       # @example
       #   Oktakit.update_group('id')
       def update_group(id, options = {})
-        put("/groups/#{id}", options)
+        put("groups/#{id}", options)
       end
 
       # Remove Group
@@ -76,7 +76,7 @@ module Oktakit
       # @example
       #   Oktakit.remove_group('id')
       def remove_group(id, options = {})
-        delete("/groups/#{id}", options)
+        delete("groups/#{id}", options)
       end
 
       # List Group Members
@@ -92,7 +92,7 @@ module Oktakit
       # @example
       #   Oktakit.list_group_members('id')
       def list_group_members(id, options = {})
-        get("/groups/#{id}/users", options)
+        get("groups/#{id}/users", options)
       end
 
       # Add User to Group
@@ -109,7 +109,7 @@ module Oktakit
       # @example
       #   Oktakit.add_user_to_group('group_id', 'user_id')
       def add_user_to_group(group_id, user_id, options = {})
-        put("/groups/#{group_id}/users/#{user_id}", options)
+        put("groups/#{group_id}/users/#{user_id}", options)
       end
 
       # Remove User from Group
@@ -126,7 +126,7 @@ module Oktakit
       # @example
       #   Oktakit.remove_user_from_group('group_id', 'user_id')
       def remove_user_from_group(group_id, user_id, options = {})
-        delete("/groups/#{group_id}/users/#{user_id}", options)
+        delete("groups/#{group_id}/users/#{user_id}", options)
       end
 
       # List Assigned Applications
@@ -142,7 +142,7 @@ module Oktakit
       # @example
       #   Oktakit.list_assigned_applications('id')
       def list_assigned_applications(id, options = {})
-        get("/groups/#{id}/apps", options)
+        get("groups/#{id}/apps", options)
       end
     end
   end

--- a/lib/oktakit/client/identity_providers.rb
+++ b/lib/oktakit/client/identity_providers.rb
@@ -13,7 +13,7 @@ module Oktakit
       # @example
       #   Oktakit.add_identity_provider
       def add_identity_provider(options = {})
-        post('/idps', options)
+        post('idps', options)
       end
 
       # Get Identity Provider
@@ -29,7 +29,7 @@ module Oktakit
       # @example
       #   Oktakit.get_identity_provider('id')
       def get_identity_provider(id, options = {})
-        get("/idps/#{id}", options)
+        get("idps/#{id}", options)
       end
 
       # List Identity Providers
@@ -44,7 +44,7 @@ module Oktakit
       # @example
       #   Oktakit.list_identity_providers
       def list_identity_providers(options = {})
-        get('/idps', options)
+        get('idps', options)
       end
 
       # Update Identity Provider
@@ -60,7 +60,7 @@ module Oktakit
       # @example
       #   Oktakit.update_identity_provider('id')
       def update_identity_provider(id, options = {})
-        put("/idps/#{id}", options)
+        put("idps/#{id}", options)
       end
 
       # Delete Identity Provider
@@ -76,7 +76,7 @@ module Oktakit
       # @example
       #   Oktakit.delete_identity_provider('id')
       def delete_identity_provider(id, options = {})
-        delete("/idps/#{id}", options)
+        delete("idps/#{id}", options)
       end
 
       # Activate Identity Provider
@@ -92,7 +92,7 @@ module Oktakit
       # @example
       #   Oktakit.activate_identity_provider('id')
       def activate_identity_provider(id, options = {})
-        post("/idps/#{id}/lifecycle/activate", options)
+        post("idps/#{id}/lifecycle/activate", options)
       end
 
       # Deactivate Identity Provider
@@ -108,7 +108,7 @@ module Oktakit
       # @example
       #   Oktakit.deactivate_identity_provider('id')
       def deactivate_identity_provider(id, options = {})
-        post("/idps/#{id}/lifecycle/deactivate", options)
+        post("idps/#{id}/lifecycle/deactivate", options)
       end
 
       # Get Identity Provider Transaction
@@ -124,7 +124,7 @@ module Oktakit
       # @example
       #   Oktakit.get_identity_provider_transaction('transaction_id')
       def get_identity_provider_transaction(transaction_id, options = {})
-        get("/idps/tx/#{transaction_id}", options)
+        get("idps/tx/#{transaction_id}", options)
       end
 
       # Get Source IdP User for IdP Transaction
@@ -140,7 +140,7 @@ module Oktakit
       # @example
       #   Oktakit.get_source_idp_user_for_idp_transaction('transaction_id')
       def get_source_idp_user_for_idp_transaction(transaction_id, options = {})
-        get("/idps/tx/#{transaction_id}/source", options)
+        get("idps/tx/#{transaction_id}/source", options)
       end
 
       # Get Target User for IdP Provision Transaction
@@ -156,7 +156,7 @@ module Oktakit
       # @example
       #   Oktakit.get_target_user_for_idp_provision_transaction('transaction_id')
       def get_target_user_for_idp_provision_transaction(transaction_id, options = {})
-        get("/idps/tx/#{transaction_id}/target", options)
+        get("idps/tx/#{transaction_id}/target", options)
       end
 
       # List Users for IdP Link Transaction
@@ -172,7 +172,7 @@ module Oktakit
       # @example
       #   Oktakit.list_users_for_idp_link_transaction('transaction_id')
       def list_users_for_idp_link_transaction(transaction_id, options = {})
-        get("/idps/tx/#{transaction_id}/users", options)
+        get("idps/tx/#{transaction_id}/users", options)
       end
 
       # Provision IdP User
@@ -188,7 +188,7 @@ module Oktakit
       # @example
       #   Oktakit.provision_idp_user('transaction_id')
       def provision_idp_user(transaction_id, options = {})
-        post("/idps/tx/#{transaction_id}/lifecycle/provision", options)
+        post("idps/tx/#{transaction_id}/lifecycle/provision", options)
       end
 
       # Link IdP User
@@ -205,7 +205,7 @@ module Oktakit
       # @example
       #   Oktakit.link_idp_user('user_id', 'transaction_id')
       def link_idp_user(transaction_id, user_id, options = {})
-        post("/idps/tx/#{transaction_id}/lifecycle/confirm/#{user_id}", options)
+        post("idps/tx/#{transaction_id}/lifecycle/confirm/#{user_id}", options)
       end
 
       # Add X.509 Certificate Public Key
@@ -220,7 +220,7 @@ module Oktakit
       # @example
       #   Oktakit.add_x509_certificate_public_key
       def add_x509_certificate_public_key(options = {})
-        post('/idps/credentials/keys', options)
+        post('idps/credentials/keys', options)
       end
 
       # Get Key
@@ -236,7 +236,7 @@ module Oktakit
       # @example
       #   Oktakit.get_key('key_id')
       def get_key(key_id, options = {})
-        get("/idps/credentials/keys/#{key_id}", options)
+        get("idps/credentials/keys/#{key_id}", options)
       end
 
       # List Keys
@@ -251,7 +251,7 @@ module Oktakit
       # @example
       #   Oktakit.list_keys
       def list_keys(options = {})
-        get('/idps/credentials/keys', options)
+        get('idps/credentials/keys', options)
       end
 
       # Delete Key
@@ -267,7 +267,7 @@ module Oktakit
       # @example
       #   Oktakit.delete_key('key_id')
       def delete_key(key_id, options = {})
-        delete("/idps/credentials/keys/#{key_id}", options)
+        delete("idps/credentials/keys/#{key_id}", options)
       end
     end
   end

--- a/lib/oktakit/client/schemas.rb
+++ b/lib/oktakit/client/schemas.rb
@@ -13,7 +13,7 @@ module Oktakit
       # @example
       #   Oktakit.get_user_schema
       def get_user_schema(options = {})
-        get('/meta/schemas/user/default', options)
+        get('meta/schemas/user/default', options)
       end
 
       # Add Property to User Profile Schema
@@ -28,7 +28,7 @@ module Oktakit
       # @example
       #   Oktakit.add_property_to_user_profile_schema
       def add_property_to_user_profile_schema(options = {})
-        post('/meta/schemas/user/default', options)
+        post('meta/schemas/user/default', options)
       end
 
       # Update User Profile Schema Property
@@ -43,7 +43,7 @@ module Oktakit
       # @example
       #   Oktakit.update_user_profile_schema_property
       def update_user_profile_schema_property(options = {})
-        post('/meta/schemas/user/default', options)
+        post('meta/schemas/user/default', options)
       end
 
       # Remove Property from User Profile Schema
@@ -58,7 +58,7 @@ module Oktakit
       # @example
       #   Oktakit.remove_property_from_user_profile_schema
       def remove_property_from_user_profile_schema(options = {})
-        post('/meta/schemas/user/default', options)
+        post('meta/schemas/user/default', options)
       end
     end
   end

--- a/lib/oktakit/client/templates.rb
+++ b/lib/oktakit/client/templates.rb
@@ -13,7 +13,7 @@ module Oktakit
       # @example
       #   Oktakit.add_sms_template
       def add_sms_template(options = {})
-        post('/templates/sms', options)
+        post('templates/sms', options)
       end
 
       # Get SMS Template
@@ -29,7 +29,7 @@ module Oktakit
       # @example
       #   Oktakit.get_sms_template('id')
       def get_sms_template(id, options = {})
-        get("/templates/sms/#{id}", options)
+        get("templates/sms/#{id}", options)
       end
 
       # List SMS Templates
@@ -44,7 +44,7 @@ module Oktakit
       # @example
       #   Oktakit.list_sms_templates
       def list_sms_templates(options = {})
-        get('/templates/sms', options)
+        get('templates/sms', options)
       end
 
       # Update Sms Template
@@ -60,7 +60,7 @@ module Oktakit
       # @example
       #   Oktakit.update_sms_template('id')
       def update_sms_template(id, options = {})
-        put("/templates/sms/#{id}", options)
+        put("templates/sms/#{id}", options)
       end
 
       # Partial SMS Template Update
@@ -76,7 +76,7 @@ module Oktakit
       # @example
       #   Oktakit.partial_sms_template_update('id')
       def partial_sms_template_update(id, options = {})
-        post("/templates/sms/#{id}", options)
+        post("templates/sms/#{id}", options)
       end
 
       # Remove SMS Template
@@ -92,7 +92,7 @@ module Oktakit
       # @example
       #   Oktakit.remove_sms_template('id')
       def remove_sms_template(id, options = {})
-        delete("/templates/sms/#{id}", options)
+        delete("templates/sms/#{id}", options)
       end
     end
   end

--- a/lib/oktakit/client/users.rb
+++ b/lib/oktakit/client/users.rb
@@ -13,7 +13,7 @@ module Oktakit
       # @example
       #   Oktakit.create_user
       def create_user(options = {})
-        post('/users', options)
+        post('users', options)
       end
 
       # Get User
@@ -29,7 +29,7 @@ module Oktakit
       # @example
       #   Oktakit.get_user('id')
       def get_user(id, options = {})
-        get("/users/#{id}", options)
+        get("users/#{id}", options)
       end
 
       # List Users
@@ -44,7 +44,7 @@ module Oktakit
       # @example
       #   Oktakit.list_users
       def list_users(options = {})
-        get('/users', options)
+        get('users', options)
       end
 
       # Update User
@@ -62,9 +62,9 @@ module Oktakit
       #   Oktakit.update_user('id')
       def update_user(id, options = {})
         if options.delete(:partial)
-          post("/users/#{id}", options)
+          post("users/#{id}", options)
         else
-          put("/users/#{id}", options)
+          put("users/#{id}", options)
         end
       end
 
@@ -81,7 +81,7 @@ module Oktakit
       # @example
       #   Oktakit.update_profile('id')
       def update_profile(id, options = {})
-        post("/users/#{id}", options)
+        post("users/#{id}", options)
       end
 
       # Get Assigned App Links
@@ -96,7 +96,7 @@ module Oktakit
       # @example
       #   Oktakit.get_assigned_app_links('id')
       def get_assigned_app_links(id, options = {})
-        get("/users/#{id}/appLinks", options)
+        get("users/#{id}/appLinks", options)
       end
 
       # Get Member Groups
@@ -112,7 +112,7 @@ module Oktakit
       # @example
       #   Oktakit.get_member_groups('id')
       def get_member_groups(id, options = {})
-        get("/users/#{id}/groups", options)
+        get("users/#{id}/groups", options)
       end
 
       # Activate User
@@ -128,7 +128,7 @@ module Oktakit
       # @example
       #   Oktakit.activate_user('id')
       def activate_user(id, options = {})
-        post("/users/#{id}/lifecycle/activate", options)
+        post("users/#{id}/lifecycle/activate", options)
       end
 
       # Deactivate User
@@ -144,7 +144,7 @@ module Oktakit
       # @example
       #   Oktakit.deactivate_user('id')
       def deactivate_user(id, options = {})
-        post("/users/#{id}/lifecycle/deactivate", options)
+        post("users/#{id}/lifecycle/deactivate", options)
       end
 
       # Suspend User
@@ -160,7 +160,7 @@ module Oktakit
       # @example
       #   Oktakit.suspend_user('id')
       def suspend_user(id, options = {})
-        post("/users/#{id}/lifecycle/suspend", options)
+        post("users/#{id}/lifecycle/suspend", options)
       end
 
       # Unsuspend User
@@ -176,7 +176,7 @@ module Oktakit
       # @example
       #   Oktakit.unsuspend_user('id')
       def unsuspend_user(id, options = {})
-        post("/users/#{id}/lifecycle/unsuspend", options)
+        post("users/#{id}/lifecycle/unsuspend", options)
       end
 
       # Unlock User
@@ -192,7 +192,7 @@ module Oktakit
       # @example
       #   Oktakit.unlock_user('id')
       def unlock_user(id, options = {})
-        post("/users/#{id}/lifecycle/unlock", options)
+        post("users/#{id}/lifecycle/unlock", options)
       end
 
       # Reset Password
@@ -208,7 +208,7 @@ module Oktakit
       # @example
       #   Oktakit.reset_password('id')
       def reset_password(id, options = {})
-        post("/users/#{id}/lifecycle/reset_password", options)
+        post("users/#{id}/lifecycle/reset_password", options)
       end
 
       # Expire Password
@@ -224,7 +224,7 @@ module Oktakit
       # @example
       #   Oktakit.expire_password('id')
       def expire_password(id, options = {})
-        post("/users/#{id}/lifecycle/expire_password", options)
+        post("users/#{id}/lifecycle/expire_password", options)
       end
 
       # Reset Factors
@@ -240,7 +240,7 @@ module Oktakit
       # @example
       #   Oktakit.reset_factors('id')
       def reset_factors(id, options = {})
-        post("/users/#{id}/lifecycle/reset_factors", options)
+        post("users/#{id}/lifecycle/reset_factors", options)
       end
 
       # Forgot Password
@@ -256,7 +256,7 @@ module Oktakit
       # @example
       #   Oktakit.forgot_password('id')
       def forgot_password(id, options = {})
-        post("/users/#{id}/credentials/forgot_password", options)
+        post("users/#{id}/credentials/forgot_password", options)
       end
 
       # Change Password
@@ -272,7 +272,7 @@ module Oktakit
       # @example
       #   Oktakit.change_password('id')
       def change_password(id, options = {})
-        post("/users/#{id}/credentials/change_password", options)
+        post("users/#{id}/credentials/change_password", options)
       end
 
       # Change Recovery Question
@@ -288,7 +288,7 @@ module Oktakit
       # @example
       #   Oktakit.change_recovery_question('id')
       def change_recovery_question(id, options = {})
-        post("/users/#{id}/credentials/change_recovery_question", options)
+        post("users/#{id}/credentials/change_recovery_question", options)
       end
 
       # Clear user sessions
@@ -303,7 +303,7 @@ module Oktakit
       # @see https://developer.okta.com/docs/api/resources/users#user-sessions
       #   Oktakit.clear_user_sessions('id')
       def clear_user_sessions(id, options = {})
-        delete("/users/#{id}/sessions", options)
+        delete("users/#{id}/sessions", options)
       end
     end
   end

--- a/spec/oktakit_spec.rb
+++ b/spec/oktakit_spec.rb
@@ -43,7 +43,7 @@ describe Oktakit do
     ERRORS.each do |code, error|
       it "raises a #{error} on #{code} responses" do
         VCR.use_cassette code do
-          expect { client.get('/users/-1') }.to raise_error(error)
+          expect { client.get('/api/v1/users/-1') }.to raise_error(error)
         end
       end
     end


### PR DESCRIPTION
The Sawyer::Agent contains the base URL to hit. Let Saywer handle the
base URL (with the path beginning) to allow for other endpoints to be created that do not depend
on such a URL. This will open doors to implement the API against the OpenID specs from https://developer.okta.com/docs/reference/api/oidc/#composing-your-base-url. 
As for example, it is not currently possible to do 

```ruby
headers = {
   # define me
}
client = Oktakit.new(api_endpoint: "http://okta-instance.okta.com")
client.post("/oauth2/default/v1/userinfo", headers: header)
```
as this will end up requesting `http://okta-instance.okta.com/api/v1/oauth2/default/v1/userinfo`


Here is an example illustrating the sawyer spec: 

```ruby
require "webmock"
require "webmock/rspec"
require "sawyer"

WebMock.enable!
include WebMock::API

describe Sawyer::Agent do
  describe "the base URL path" do
    it "is ignored on an abosulute path" do
      request = stub_request(:get, "http://api.example.com/bar")

      agent = described_class.new("http://api.example.com/foo")
      agent.call(:get, "/bar")
      expect(request).to have_been_made
    end

    it "is included on an relative path" do
      request = stub_request(:get, "http://api.example.com/foo/bar")

      agent = described_class.new("http://api.example.com/foo")
      agent.call(:get, "bar")
      expect(request).to have_been_made
    end

    it "is doesn't matter if the endpoint does not contain a path" do
      request = stub_request(:get, "http://api.example.com/bar")

      agent = described_class.new("http://api.example.com")
      agent.call(:get, "bar")
      expect(request).to have_been_made
    end
  end
end
```