### PR TITLE
Added ability to use Okta OAuth 2.0 access token instead of just API token

### DIFF
--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -201,7 +201,7 @@ module Oktakit
 
     def absolute_to_relative_url(next_ref)
       return unless next_ref
-      
+
       next_ref.href.sub(api_endpoint, '')
     end
   end

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -36,7 +36,7 @@ module Oktakit
         raise ArgumentError, "Please provide either the organization or the api_endpoint argument"
       end
 
-      if token.blank? && access_token.blank?
+      if token.nil? && access_token.nil?
         raise ArgumentError, "Please provide either the token or the access_token argument"
       end
 

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -36,7 +36,7 @@ module Oktakit
         raise ArgumentError, "Please provide either the organization or the api_endpoint argument"
       end
 
-      if token.nil? && access_token.nil?
+      if (token.nil? && access_token.nil?) || (token && access_token)
         raise ArgumentError, "Please provide either the token or the access_token argument"
       end
 

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -31,12 +31,17 @@ module Oktakit
       builder.adapter Faraday.default_adapter
     end
 
-    def initialize(token:, organization: nil, api_endpoint: nil)
+    def initialize(token: nil, access_token: nil, organization: nil, api_endpoint: nil)
       if organization.nil? && api_endpoint.nil?
         raise ArgumentError, "Please provide either the organization or the api_endpoint argument"
       end
 
+      if token.blank? && access_token.blank?
+        raise ArgumentError, "Please provide either the token or the access_token argument"
+      end
+
       @token = token
+      @access_token = access_token
       @organization = organization
       @api_endpoint = api_endpoint
     end
@@ -182,7 +187,8 @@ module Oktakit
         http.headers[:accept] = 'application/json'
         http.headers[:content_type] = 'application/json'
         http.headers[:user_agent] = "Oktakit v#{Oktakit::VERSION}"
-        http.authorization 'SSWS ', @token
+        http.authorization 'SSWS ', @token if @token
+        http.authorization :Bearer, @access_token if @access_token
       end
     end
 
@@ -195,7 +201,7 @@ module Oktakit
 
     def absolute_to_relative_url(next_ref)
       return unless next_ref
-
+      
       next_ref.href.sub(api_endpoint, '')
     end
   end


### PR DESCRIPTION
This library currently only supports API token authentication with Okta APIs. I've made this small change to add the support for OAuth 2.0 access token in addition to the API token.

I'd be happy to make any changes that are required or someone else to jump in and conclude the PR. It's working fine for my use case.