### PR TITLE
Fix RaiseError middleware for Faraday v1.2.0

### DIFF
--- a/lib/oktakit/response/raise_error.rb
+++ b/lib/oktakit/response/raise_error.rb
@@ -7,8 +7,6 @@ module Oktakit
     # This class raises an Oktakit-flavored exception based
     # HTTP status codes returned by the API
     class RaiseError < Faraday::Response::Middleware
-      private
-
       def on_complete(response)
         if (error = Oktakit::Error.from_response(response))
           raise error


### PR DESCRIPTION
In Faraday v1.2.0, they added the following feature:
> Introduces on_request and on_complete methods in Faraday::Middleware.

[See CHANGELOG](https://github.com/lostisland/faraday/blob/master/CHANGELOG.md#v120-2020-12-23)

Rather than calling `on_complete(environment)` from inside `Faraday::Response::Middleware`, they now call `on_complete(environment) if respond_to?(:on_complete)` from inside `Faraday::Middleware`. Since our `on_complete` method is private, the call to `respond_to?` returns false and the middleware is never called.

See change: https://github.com/lostisland/faraday/commit/d56742a174fe9f2f9f3d46438324fcac0d2381f7

Simple way to fix this is to make the `on_complete` method public. This is also what Faraday does for its own middleware.