### PR TITLE
Ruby 3 update

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ The [API Test Client](https://developer.okta.com/docs/api/getting_started/api_te
 
 ## Contributing
 
-1. Fork it ( <https://github.com/hopify/oktakit/fork> )
+1. Fork it ( <https://github.com/shopify/oktakit/fork> )
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)

--- a/lib/oktakit.rb
+++ b/lib/oktakit.rb
@@ -2,7 +2,7 @@ require 'oktakit/version'
 require 'oktakit/client'
 
 module Oktakit
-  def self.new(*args)
-    Client.new(*args)
+  def self.new(**args)
+    Client.new(**args)
   end
 end

--- a/spec/oktakit_spec.rb
+++ b/spec/oktakit_spec.rb
@@ -5,6 +5,13 @@ describe Oktakit do
     expect(Oktakit::VERSION).not_to(be(nil))
   end
 
+  describe '.new' do
+    it 'creates a client with the passed in keyword arguments' do
+      client = Oktakit.new(token: test_okta_token, organization: 'okta-test')
+      expect(client.api_endpoint).to(eq('https://okta-test.okta.com/api/v1'))
+    end
+  end
+
   describe 'client' do
     it 'has a default API endpoint' do
       client = Oktakit::Client.new(token: test_okta_token, organization: 'okta-test')


### PR DESCRIPTION
The `Oktakit.new` convenience method will not work in Ruby 3. More details in commit 1cb45ea