### PR TITLE
Make error details public

### DIFF
--- a/lib/oktakit/error.rb
+++ b/lib/oktakit/error.rb
@@ -48,11 +48,11 @@ module Oktakit
       end
     end
 
-    private
-
     def data
       @data ||= parse_data
     end
+
+    private
 
     def parse_data
       body = @response[:body]


### PR DESCRIPTION
This PR re-implements https://github.com/Shopify/oktakit/pull/28 without the rubocop changes.
The `data` method on `Oktakit::Error` is now public and can be accessed from outside to get details on the error that has occurred.