### PR TITLE
Make Oktakit::Response::RaiseError#on_complete public

### DIFF
--- a/lib/oktakit/response/raise_error.rb
+++ b/lib/oktakit/response/raise_error.rb
@@ -7,8 +7,6 @@ module Oktakit
     # This class raises an Oktakit-flavored exception based
     # HTTP status codes returned by the API
     class RaiseError < Faraday::Response::Middleware
-      private
-
       def on_complete(response)
         if (error = Oktakit::Error.from_response(response))
           raise error


### PR DESCRIPTION
A respond_to? guard clause in Faraday::Middleware prevents this callback from ever executing when the method is private, which was causing test failures.

See https://github.com/lostisland/faraday/blob/main/lib/faraday/middleware.rb#L18