### PR TITLE
Add linux to Gemfile.lock platforms

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
 PLATFORMS
   -darwin-21
   arm64-darwin-21
+  x86_64-linux
 
 DEPENDENCIES
   bundler


### PR DESCRIPTION
Does what it says on the tin. Allows builds to pass on linux. :-)