### PR TITLE
Revert raise-on-non-2xx response behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v0.3.1] - 2022-01-20
+- [Reverts a breaking change that caused errors to be raised for non-2xx responses](https://github.com/Shopify/oktakit/pull/54)
+
 ## [v0.3.0] - 2022-01-20
 - [Adds support for Ruby 3](https://github.com/Shopify/oktakit/pull/42)
 - [Adds support for user reactivation endpoint](https://github.com/Shopify/oktakit/pull/47)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    oktakit (0.3.0)
+    oktakit (0.3.1)
       sawyer (~> 0.8.1)
 
 GEM

--- a/lib/oktakit/response/raise_error.rb
+++ b/lib/oktakit/response/raise_error.rb
@@ -7,6 +7,8 @@ module Oktakit
     # This class raises an Oktakit-flavored exception based
     # HTTP status codes returned by the API
     class RaiseError < Faraday::Response::Middleware
+      private
+
       def on_complete(response)
         if (error = Oktakit::Error.from_response(response))
           raise error

--- a/lib/oktakit/version.rb
+++ b/lib/oktakit/version.rb
@@ -1,3 +1,3 @@
 module Oktakit
-  VERSION = '0.3.0'.freeze
+  VERSION = '0.3.1'.freeze
 end

--- a/spec/oktakit_spec.rb
+++ b/spec/oktakit_spec.rb
@@ -46,13 +46,13 @@ describe Oktakit do
     504 => Oktakit::ServerError,
   }
 
-  describe 'errors' do
-    ERRORS.each do |code, error|
-      it "raises a #{error} on #{code} responses" do
-        VCR.use_cassette(code) do
-          expect { client.get('/users/-1') }.to(raise_error(error))
-        end
-      end
-    end
-  end
+  # describe 'errors' do
+  #   ERRORS.each do |code, error|
+  #     it "raises a #{error} on #{code} responses" do
+  #       VCR.use_cassette(code) do
+  #         expect { client.get('/users/-1') }.to(raise_error(error))
+  #       end
+  #     end
+  #   end
+  # end
 end

--- a/spec/oktakit_spec.rb
+++ b/spec/oktakit_spec.rb
@@ -28,31 +28,32 @@ describe Oktakit do
     end
   end
 
-  ERRORS = {
-    400 => Oktakit::BadRequest,
-    401 => Oktakit::Unauthorized,
-    403 => Oktakit::Forbidden,
-    404 => Oktakit::NotFound,
-    405 => Oktakit::MethodNotAllowed,
-    406 => Oktakit::NotAcceptable,
-    409 => Oktakit::Conflict,
-    415 => Oktakit::UnsupportedMediaType,
-    422 => Oktakit::UnprocessableEntity,
-    418 => Oktakit::ClientError,
-    500 => Oktakit::InternalServerError,
-    501 => Oktakit::NotImplemented,
-    502 => Oktakit::BadGateway,
-    503 => Oktakit::ServiceUnavailable,
-    504 => Oktakit::ServerError,
-  }
+  ERROR_STATUSES = [
+    400,
+    401,
+    403,
+    404,
+    405,
+    406,
+    409,
+    415,
+    422,
+    418,
+    500,
+    501,
+    502,
+    503,
+    504,
+  ]
 
-  # describe 'errors' do
-  #   ERRORS.each do |code, error|
-  #     it "raises a #{error} on #{code} responses" do
-  #       VCR.use_cassette(code) do
-  #         expect { client.get('/users/-1') }.to(raise_error(error))
-  #       end
-  #     end
-  #   end
-  # end
+  describe 'errors' do
+    ERROR_STATUSES.each do |error_status|
+      it "returns a #{error_status} status for #{error_status} responses" do
+        VCR.use_cassette(error_status) do
+          _, response_status = client.get('/users/-1')
+          expect(response_status).to eq(error_status)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
https://github.com/Shopify/oktakit/commit/3b02b32276fab70e21a017d62ec9eea67996a906 aimed to fix the originally intended behavior of raising custom errors for most non-2xx responses. This however resulted in a fairly significant change to the actual interface of the 0.2.0 release (in which this behavior seems to have not been working as intended), so we're reverting it.

We may restore the error raising behavior behind a feature flag in an upcoming release.