### PR TITLE
Fix 'Faraday::Connection#authorization' deprecation warning

### DIFF
--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -189,8 +189,8 @@ module Oktakit
         http.headers[:accept] = 'application/json'
         http.headers[:content_type] = 'application/json'
         http.headers[:user_agent] = "Oktakit v#{Oktakit::VERSION}"
-        http.authorization('SSWS ', @token) if @token
-        http.authorization(:Bearer, @access_token) if @access_token
+        http.headers[:authorization] = "SSWS #{@token}" if @token
+        http.headers[:authorization] = "Bearer #{@access_token}" if @access_token
       end
     end
 


### PR DESCRIPTION
Fixes a the Faraday deprecation warning:

```
WARNING: `Faraday::Connection#authorization` is deprecated; it will be removed in version 2.0.
While initializing your connection, use `#request(:authorization, ...)` instead.
See https://lostisland.github.io/faraday/middleware/authentication for more usage info.
```

The solution was taken from this oktokit PR https://github.com/octokit/octokit.rb/pull/1359. Specifically the change to this file 

https://github.com/octokit/octokit.rb/pull/1359/files#diff-049c21c25599adc0dd5306bf783df23cd13a20af81ffee0a7bc9bc44b62907e2