### PR TITLE
Pass HTTP status to `Oktakit::Error.from_response()`

### DIFF
--- a/lib/oktakit/response/raise_error.rb
+++ b/lib/oktakit/response/raise_error.rb
@@ -9,8 +9,8 @@ module Oktakit
     class RaiseError < Faraday::Response::Middleware
       private
 
-      def on_complete(response)
-        if (error = Oktakit::Error.from_response(response))
+      def on_complete(response, status)
+        if (error = Oktakit::Error.from_response(response, status))
           raise error
         end
       end

--- a/spec/error_spec.rb
+++ b/spec/error_spec.rb
@@ -1,0 +1,91 @@
+require "spec_helper"
+
+describe Oktakit::Error do
+  describe "#from_response(response)" do
+    context "success" do
+      subject(:from_response) { described_class.from_response(okta_response, 404) }
+
+      context "with response and status" do
+        let(:okta_response) do
+          {
+            errorCode: "00000000",
+            errorSummary: "Not found: Resource not found: example@example.com (User)",
+            errorLink: "E0000007",
+            errorId: "00000000",
+            errorCauses: [],
+          }
+        end
+
+        it "returns an instance of the described class" do
+          expect(from_response.class).to(eq(Oktakit::NotFound))
+        end
+
+        it "returns a meaningful error message" do
+          expected_message = "404 - Not found: Resource not found: example@example.com (User)"
+
+          expect(from_response.message).to(eq(expected_message))
+        end
+      end
+
+      context "with missing response" do
+        let(:okta_response) { {} }
+
+        it "returns an instance of the described class" do
+          expect(from_response.class).to(eq(Oktakit::NotFound))
+        end
+
+        it "returns a meaningful error message" do
+          expect(from_response.message).to(eq("404"))
+        end
+      end
+
+      context "with a different response format" do
+        let(:okta_response) do
+          {
+            status: 404,
+            method: "POST",
+            url: "http://example.com/api/v1",
+            response_headers: {
+              content_type: "json",
+            },
+            body: {
+              errorCode: "E0000007",
+              errorSummary: "Not found: Resource not found: abrakadabrasdfskdkf@admin.com (User)",
+              errorLink: "E0000007",
+              errorId: "oaeLRic8zbhTBiJ81eJnWTQUg",
+              errorCauses: [],
+            },
+          }
+        end
+
+        it "returns an instance of the described class" do
+          expect(from_response.class).to(eq(Oktakit::NotFound))
+        end
+
+        it "returns a meaningful error message" do
+          expected_message = "POST http://example.com/api/v1 : 404"
+
+          expect(from_response.message).to(eq(expected_message))
+        end
+      end
+    end
+
+    context "with errors" do
+      context "with missing status" do
+        subject(:from_response) { described_class.from_response(okta_response, 0) }
+
+        let(:okta_response) do
+          {
+            errorCode: "00000000",
+            errorSummary: "Not found: Resource not found: example@example.com (User)",
+            errorLink: "E0000007",
+            errorId: "00000000",
+            errorCauses: [],
+          }
+        end
+
+        it { is_expected.to(be_nil) }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This fixes https://github.com/Shopify/oktakit/issues/59 by
modifying `Oktakit::Error.from_response()` method to accept and
process client response and HTTP status.

The reason behind these changes:
```ruby
response, http_status = client.get_user('example@example.com')
```
This usage method is listed in the repo's README and works in most
cases. However, it separates response from HTTP status. `response` is a
`Sawyer::Resource` object and doesn't contain any data about the request
(HTTP status, URL, method or headers). It only has a Hash with Okta
error code, error summary, internal error link, error id and error
causes, which causes a `TypeError` if we try to
`raise Oktakit::Error.from_response(response) unless http_status == 200`
in case the user is not found.

With these changes implemented, we will gain the ability to process
different response formats without causing errors on the client side.