### PR TITLE
Loosen sawyer dependency to allow 0.9.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     oktakit (0.3.2)
-      sawyer (~> 0.8.1)
+      sawyer (>= 0.8.1, < 0.10)
 
 GEM
   remote: https://rubygems.org/

--- a/oktakit.gemspec
+++ b/oktakit.gemspec
@@ -19,6 +19,6 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 2.6'
 
-  spec.add_dependency('sawyer', '~> 0.8.1')
+  spec.add_dependency('sawyer', '>= 0.8.1', '< 0.10')
   spec.add_development_dependency('bundler')
 end


### PR DESCRIPTION
Relaxing sawyer dependency. 

Main reason being a vulnerability found in octokit. https://github.com/Shopify/billing/issues/14003.

Octokit should be updated to `4.25.0`, however its gemspec adds sawyer dependency as `~> 0.9` (https://github.com/octokit/octokit.rb/blob/main/octokit.gemspec#L10)