### PR TITLE
Upgrade to Faraday 2.x

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     oktakit (0.3.3)
-      faraday (>= 0.17.3, < 2)
+      faraday (>= 2.0.1, < 3)
       sawyer (>= 0.8.1, < 0.10)
 
 GEM
@@ -13,30 +13,10 @@ GEM
     ast (2.4.2)
     byebug (11.1.3)
     diff-lcs (1.4.4)
-    faraday (1.10.0)
-      faraday-em_http (~> 1.0)
-      faraday-em_synchrony (~> 1.0)
-      faraday-excon (~> 1.1)
-      faraday-httpclient (~> 1.0)
-      faraday-multipart (~> 1.0)
-      faraday-net_http (~> 1.0)
-      faraday-net_http_persistent (~> 1.0)
-      faraday-patron (~> 1.0)
-      faraday-rack (~> 1.0)
-      faraday-retry (~> 1.0)
+    faraday (2.6.0)
+      faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-em_http (1.0.0)
-    faraday-em_synchrony (1.0.0)
-    faraday-excon (1.1.0)
-    faraday-httpclient (1.0.1)
-    faraday-multipart (1.0.4)
-      multipart-post (~> 2)
-    faraday-net_http (1.0.1)
-    faraday-net_http_persistent (1.2.0)
-    faraday-patron (1.0.0)
-    faraday-rack (1.0.0)
-    faraday-retry (1.0.3)
-    multipart-post (2.2.3)
+    faraday-net_http (3.0.1)
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
@@ -99,4 +79,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.2.22
+   2.3.24

--- a/lib/oktakit/client.rb
+++ b/lib/oktakit/client.rb
@@ -24,13 +24,10 @@ module Oktakit
     include Templates
     include Users
 
-    # In Faraday 0.9, Faraday::Builder was renamed to Faraday::RackBuilder
-    RACK_BUILDER_CLASS = defined?(Faraday::RackBuilder) ? Faraday::RackBuilder : Faraday::Builder
-
     # Default Faraday middleware stack
-    MIDDLEWARE = RACK_BUILDER_CLASS.new do |builder|
+    MIDDLEWARE = Faraday::RackBuilder.new do |builder|
       builder.use(Oktakit::Response::RaiseError)
-      builder.adapter(Faraday.default_adapter)
+      builder.adapter(:net_http)
     end
 
     def initialize(token: nil, access_token: nil, organization: nil, api_endpoint: nil)

--- a/lib/oktakit/response/raise_error.rb
+++ b/lib/oktakit/response/raise_error.rb
@@ -6,7 +6,7 @@ module Oktakit
   module Response
     # This class raises an Oktakit-flavored exception based
     # HTTP status codes returned by the API
-    class RaiseError < Faraday::Response::Middleware
+    class RaiseError < Faraday::Middleware
       private
 
       def on_complete(response)

--- a/oktakit.gemspec
+++ b/oktakit.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |spec|
   spec.required_ruby_version = '>= 2.6'
 
   spec.add_dependency('sawyer', '>= 0.8.1', '< 0.10')
-  spec.add_dependency('faraday', '>= 0.17.3', '< 2')
+  spec.add_dependency('faraday', '>= 2.0.1', '< 3')
   spec.add_development_dependency('bundler')
 end


### PR DESCRIPTION
Fixes #41 

I made it require a version greater than 2.0.1, [as recommended](https://github.com/lostisland/faraday/blob/main/UPGRADING.md) by their own guide.