### PR TITLE
Bump gem version to 1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [v1.0.0] - 2023-07-12
+- [Upgrade to Faraday 2.x](https://github.com/Shopify/oktakit/pull/68)
+
 ## [v0.3.3] - 2022-07-20
 - [Loosen sawyer dependency to allow 0.9.1](https://github.com/Shopify/oktakit/pull/61)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,26 +1,26 @@
 PATH
   remote: .
   specs:
-    oktakit (0.3.3)
+    oktakit (1.0.0)
       faraday (>= 2.0.1, < 3)
       sawyer (>= 0.8.1, < 0.10)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.0)
-      public_suffix (>= 2.0.2, < 5.0)
+    addressable (2.8.4)
+      public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     byebug (11.1.3)
     diff-lcs (1.4.4)
-    faraday (2.6.0)
+    faraday (2.7.10)
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
-    faraday-net_http (3.0.1)
+    faraday-net_http (3.0.2)
     parallel (1.21.0)
     parser (3.0.3.2)
       ast (~> 2.4.1)
-    public_suffix (4.0.7)
+    public_suffix (5.0.3)
     rainbow (3.0.0)
     rake (13.0.6)
     regexp_parser (2.2.0)

--- a/lib/oktakit/version.rb
+++ b/lib/oktakit/version.rb
@@ -1,3 +1,3 @@
 module Oktakit
-  VERSION = '0.3.3'.freeze
+  VERSION = '1.0.0'.freeze
 end


### PR DESCRIPTION
Bump gem version to 1.0.0. This is a potential breaking change because of the new Faraday version requirements. 